### PR TITLE
Add out-of-range testing for ints and floats

### DIFF
--- a/include/fast_matrix_market/field_conv.hpp
+++ b/include/fast_matrix_market/field_conv.hpp
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <charconv>
+#include <cmath>
 #include <complex>
+#include <limits>
 #include <iomanip>
 #include <type_traits>
 
@@ -55,69 +57,143 @@ namespace fast_matrix_market {
      * Parse integer using std::from_chars
      */
     template <typename IT>
-    const char* read_int(const char* pos, const char* end, IT& out) {
+    const char* read_int_from_chars(const char* pos, const char* end, IT& out) {
         std::from_chars_result result = std::from_chars(pos, end, out);
         if (result.ec != std::errc()) {
-            throw invalid_mm("Invalid integer value.");
+            if (result.ec == std::errc::result_out_of_range) {
+                throw out_of_range("Integer out of range.");
+            } else {
+                throw invalid_mm("Invalid integer value.");
+            }
         }
         return result.ptr;
     }
-#else
+#endif
+
+    inline const char* read_int_fallback(const char* pos, [[maybe_unused]] const char* end, long long& out) {
+        errno = 0;
+
+        char* value_end;
+        out = std::strtoll(pos, &value_end, 10);
+        if (errno != 0 || pos == value_end) {
+            if (errno == ERANGE) {
+                throw out_of_range("Integer out of range.");
+            } else {
+                throw invalid_mm("Invalid integer value.");
+            }
+        }
+
+        return value_end;
+    }
+
+    inline const char* read_int_fallback(const char* pos, [[maybe_unused]] const char* end, unsigned long long& out) {
+        errno = 0;
+
+        char *value_end;
+        out = std::strtoull(pos, &value_end, 10);
+        if (errno != 0 || pos == value_end) {
+            if (errno == ERANGE) {
+              throw out_of_range("Integer out of range.");
+            } else {
+                throw invalid_mm("Invalid integer value.");
+            }
+        }
+        return value_end;
+    }
+
     /**
      * Parse integers using C routines.
      *
      * This is a compatibility fallback.
      */
     template <typename T>
-    const char* read_int(const char* pos, [[maybe_unused]] const char* end, T& out) {
-        errno = 0;
+    const char* read_int_fallback(const char* pos, const char* end, T& out) {
+        long long i64;
+        const char* ret = read_int_fallback(pos, end, i64);
 
-        char* value_end;
-        long long parsed_value = std::strtoll(pos, &value_end, 10);
-        if (errno != 0 || pos == value_end) {
-            throw invalid_mm("Invalid integer value.");
+        if (sizeof(T) < sizeof(long long)) {
+            if (i64 > (long long) std::numeric_limits<T>::max() ||
+                i64 < (long long) std::numeric_limits<T>::min()) {
+                throw out_of_range(std::string("Integer out of range."));
+            }
         }
-        out = static_cast<T>(parsed_value);
-        return value_end;
+        out = static_cast<T>(i64);
+        return ret;
     }
+
+    /**
+     * Parse integer using best available method
+     */
+    template <typename IT>
+    const char* read_int(const char* pos, const char* end, IT& out) {
+#ifdef FMM_FROM_CHARS_INT_SUPPORTED
+        return read_int_from_chars(pos, end, out);
+#else
+        return read_int_fallback(pos, end, out);
 #endif
+    }
 
 #ifdef FMM_USE_FAST_FLOAT
     /**
      * Parse float or double using fast_float::from_chars
      */
     template <typename FT>
-    const char* read_float(const char* pos, const char* end, FT& out) {
+    const char* read_float_fast_float(const char* pos, const char* end, FT& out, out_of_range_behavior oorb) {
         fast_float::from_chars_result result = fast_float::from_chars(pos, end, out, fast_float::chars_format::general);
+
         if (result.ec != std::errc()) {
-            throw invalid_mm("Invalid floating-point value.");
+            if (result.ec == std::errc::result_out_of_range) {
+                if (oorb == ThrowOutOfRange) {
+                    throw out_of_range("Floating-point value out of range.");
+                }
+            } else {
+                throw invalid_mm("Invalid floating-point value.");
+            }
         }
         return result.ptr;
     }
-#elif defined(FMM_FROM_CHARS_DOUBLE_SUPPORTED)
+#endif
+
+
+#ifdef FMM_FROM_CHARS_DOUBLE_SUPPORTED
     /**
      * Parse float or double using std::from_chars
      */
     template <typename FT>
-    const char* read_float(const char* pos, const char* end, FT& out) {
+    const char* read_float_from_chars(const char* pos, const char* end, FT& out, out_of_range_behavior oorb) {
         std::from_chars_result result = std::from_chars(pos, end, out);
         if (result.ec != std::errc()) {
-            throw invalid_mm("Invalid floating-point value.");
+            if (result.ec == std::errc::result_out_of_range) {
+                if (oorb == ThrowOutOfRange) {
+                    throw out_of_range("Floating-point overflow");
+                } else {
+                    // std::from_chars does not return a best match on under/overflow, so fall back to strtod
+                    out = std::strtod(pos, nullptr);
+                }
+            } else {
+                throw invalid_mm("Invalid floating-point value.");
+            }
         }
         return result.ptr;
     }
+#endif
 
-#else
     /**
      * Parse double using strtod(). This is a compatibility fallback.
      */
-    inline const char* read_float(const char* pos, [[maybe_unused]] const char* end, double& out) {
+    inline const char* read_float_fallback(const char* pos, [[maybe_unused]] const char* end, double& out, out_of_range_behavior oorb = ThrowOutOfRange) {
         errno = 0;
 
         char* value_end;
         out = std::strtod(pos, &value_end);
         if (errno != 0 || pos == value_end) {
-            throw invalid_mm("Invalid floating-point value.");
+            if (errno == ERANGE) {
+                if (oorb == ThrowOutOfRange) {
+                    throw out_of_range("Floating-point value out of range.");
+                }
+            } else {
+                throw invalid_mm("Invalid floating-point value.");
+            }
         }
         return value_end;
     }
@@ -125,47 +201,85 @@ namespace fast_matrix_market {
     /**
      * Parse float using strtof(). This is a compatibility fallback.
      */
-    inline const char* read_float(const char* pos, [[maybe_unused]] const char* end, float& out) {
+    inline const char* read_float_fallback(const char* pos, [[maybe_unused]] const char* end, float& out, out_of_range_behavior oorb) {
         errno = 0;
 
         char* value_end;
         out = std::strtof(pos, &value_end);
         if (errno != 0 || pos == value_end) {
-            throw invalid_mm("Invalid floating-point value.");
+            if (errno == ERANGE) {
+                if (oorb == ThrowOutOfRange) {
+                    throw out_of_range("Floating-point value out of range.");
+                }
+            } else {
+                throw invalid_mm("Invalid floating-point value.");
+            }
         }
         return value_end;
     }
 
+    template <typename FT>
+    const char* read_float(const char* pos, const char* end, FT& out, out_of_range_behavior oorb) {
+#ifdef FMM_USE_FAST_FLOAT
+        return read_float_fast_float(pos, end, out, oorb);
+#elif defined(FMM_FROM_CHARS_DOUBLE_SUPPORTED)
+        return read_float_from_chars(pos, end, out, oorb);
+#else
+        return read_float_fallback(pos, end, out, oorb);
 #endif
+    }
 
 #ifdef FMM_FROM_CHARS_LONG_DOUBLE_SUPPORTED
     /**
      * Parse long double using std::from_chars
      */
-    inline const char* read_float(const char* pos, const char* end, long double& out) {
+    inline const char* read_float_from_chars(const char* pos, const char* end, long double& out, out_of_range_behavior oorb) {
         std::from_chars_result result = std::from_chars(pos, end, out);
         if (result.ec != std::errc()) {
-            throw invalid_mm("Invalid floating-point value.");
+            if (result.ec == std::errc::result_out_of_range) {
+                if (oorb == ThrowOutOfRange) {
+                    throw out_of_range("Floating-point value out of range.");
+                } else {
+                    // std::from_chars does not return a best match on under/overflow, so fall back to strtold
+                    out = std::strtold(pos, nullptr);
+                }
+            } else {
+                throw invalid_mm("Invalid floating-point value.");
+            }
         }
         return result.ptr;
     }
-#else
+#endif
+
     /**
      * Parse `long double` using std::strtold().
      *
      * fast_float does not support long double.
      */
-    inline const char* read_float(const char* pos, [[maybe_unused]] const char* end, long double& out) {
+    inline const char* read_float_fallback(const char* pos, [[maybe_unused]] const char* end, long double& out, out_of_range_behavior oorb) {
         errno = 0;
 
         char* value_end;
         out = std::strtold(pos, &value_end);
         if (errno != 0 || pos == value_end) {
-            throw invalid_mm("Invalid floating-point value.");
+            if (errno == ERANGE) {
+                if (oorb == ThrowOutOfRange) {
+                    throw out_of_range("Floating-point value out of range.");
+                }
+            } else {
+                throw invalid_mm("Invalid floating-point value.");
+            }
         }
         return value_end;
     }
+
+    inline const char* read_float(const char* pos, [[maybe_unused]] const char* end, long double& out, out_of_range_behavior oorb) {
+#ifdef FMM_FROM_CHARS_LONG_DOUBLE_SUPPORTED
+        return read_float_from_chars(pos, end, out, oorb);
+#else
+        return read_float_fallback(pos, end, out, oorb);
 #endif
+    }
 
     //////////////////////////////////////
     // Read value. These evaluate to the field parsers above, depending on requested type
@@ -174,40 +288,40 @@ namespace fast_matrix_market {
     /**
      * Pattern values are no-ops.
      */
-    inline const char* read_value(const char* pos, [[maybe_unused]] const char* end, [[maybe_unused]] pattern_placeholder_type& out) {
+    inline const char* read_value(const char* pos, [[maybe_unused]] const char* end, [[maybe_unused]] pattern_placeholder_type& out, [[maybe_unused]] const read_options& options = {}) {
         return pos;
     }
 
     template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
-    const char* read_value(const char* pos, const char* end, T& out) {
+    const char* read_value(const char* pos, const char* end, T& out, [[maybe_unused]] const read_options& options = {}) {
         return read_int(pos, end, out);
     }
 
-    inline const char* read_value(const char* pos, const char* end, bool& out) {
+    inline const char* read_value(const char* pos, const char* end, bool& out, const read_options& options = {}) {
         double parsed;
-        auto ret = read_float(pos, end, parsed);
+        auto ret = read_float(pos, end, parsed, options.float_out_of_range_behavior);
         out = (parsed != 0);
         return ret;
     }
 
-    inline const char* read_value(const char* pos, const char* end, float& out) {
-        return read_float(pos, end, out);
+    inline const char* read_value(const char* pos, const char* end, float& out, const read_options& options = {}) {
+        return read_float(pos, end, out, options.float_out_of_range_behavior);
     }
 
-    inline const char* read_value(const char* pos, const char* end, double& out) {
-        return read_float(pos, end, out);
+    inline const char* read_value(const char* pos, const char* end, double& out, const read_options& options = {}) {
+        return read_float(pos, end, out, options.float_out_of_range_behavior);
     }
 
-    inline const char* read_value(const char* pos, const char* end, long double& out) {
-        return read_float(pos, end, out);
+    inline const char* read_value(const char* pos, const char* end, long double& out, const read_options& options = {}) {
+        return read_float(pos, end, out, options.float_out_of_range_behavior);
     }
 
     template <typename COMPLEX, typename std::enable_if<is_complex<COMPLEX>::value, int>::type = 0>
-    const char* read_value(const char* pos, const char* end, COMPLEX& out) {
+    const char* read_value(const char* pos, const char* end, COMPLEX& out, const read_options& options = {}) {
         typename COMPLEX::value_type real, imaginary;
-        pos = read_float(pos, end, real);
+        pos = read_float(pos, end, real, options.float_out_of_range_behavior);
         pos = skip_spaces(pos);
-        pos = read_float(pos, end, imaginary);
+        pos = read_float(pos, end, imaginary, options.float_out_of_range_behavior);
 
         out.real(real);
         out.imag(imaginary);

--- a/include/fast_matrix_market/header.hpp
+++ b/include/fast_matrix_market/header.hpp
@@ -166,15 +166,20 @@ namespace fast_matrix_market {
         // parse the dimension line
         {
             std::istringstream iss(line);
+            const char* pos = line.c_str();
+            const char* end = line.c_str() + line.size();
+            pos = skip_spaces(pos);
 
             if (header.object == vector) {
-                iss >> header.vector_length;
+                pos = read_int(pos, end, header.vector_length);
+
                 if (header.vector_length < 0) {
                     throw invalid_mm("Vector length can't be negative.", lines_read);
                 }
 
                 if (header.format == coordinate) {
-                    iss >> header.nnz;
+                    pos = skip_spaces(pos);
+                    pos = read_int(pos, end, header.nnz);
                 } else {
                     header.nnz = header.vector_length;
                 }
@@ -182,13 +187,16 @@ namespace fast_matrix_market {
                 header.nrows = header.vector_length;
                 header.ncols = 1;
             } else {
-                iss >> header.nrows >> header.ncols;
+                pos = read_int(pos, end, header.nrows);
+                pos = skip_spaces(pos);
+                pos = read_int(pos, end, header.ncols);
                 if (header.nrows < 0 || header.ncols < 0) {
                     throw invalid_mm("Matrix dimensions can't be negative.", lines_read);
                 }
 
                 if (header.format == coordinate) {
-                    iss >> header.nnz;
+                    pos = skip_spaces(pos);
+                    pos = read_int(pos, end, header.nnz);
                     if (header.nnz < 0) {
                         throw invalid_mm("Matrix NNZ can't be negative.", lines_read);
                     }
@@ -201,6 +209,11 @@ namespace fast_matrix_market {
                 } else {
                     header.vector_length = -1;
                 }
+            }
+
+            pos = skip_spaces(pos);
+            if (pos != end) {
+                throw invalid_mm("Unexpected value in header dimension line");
             }
         }
 

--- a/include/fast_matrix_market/read_body.hpp
+++ b/include/fast_matrix_market/read_body.hpp
@@ -104,7 +104,7 @@ namespace fast_matrix_market {
                 pos = skip_spaces(pos);
                 pos = read_int(pos, end, col);
                 pos = skip_spaces(pos);
-                pos = read_value(pos, end, value);
+                pos = read_value(pos, end, value, options);
                 pos = bump_to_next_line(pos, end);
 
                 // validate
@@ -159,7 +159,7 @@ namespace fast_matrix_market {
 
     template<typename HANDLER>
     int64_t read_chunk_vector_coordinate(const std::string &chunk, const matrix_market_header &header, int64_t line_num,
-                                         HANDLER &handler) {
+                                         HANDLER &handler, const read_options &options) {
         const char *pos = chunk.c_str();
         const char *end = pos + chunk.size();
 
@@ -175,7 +175,7 @@ namespace fast_matrix_market {
                 pos = skip_spaces(pos);
                 pos = read_int(pos, end, row);
                 pos = skip_spaces(pos);
-                pos = read_value(pos, end, value);
+                pos = read_value(pos, end, value, options);
                 pos = bump_to_next_line(pos, end);
 
                 // validate
@@ -222,7 +222,7 @@ namespace fast_matrix_market {
                 typename HANDLER::value_type value;
 
                 pos = skip_spaces(pos);
-                pos = read_value(pos, end, value);
+                pos = read_value(pos, end, value, options);
                 pos = bump_to_next_line(pos, end);
 
                 handler.handle(row, col, value);
@@ -295,7 +295,7 @@ namespace fast_matrix_market {
             if (header.object == matrix) {
                 line_num = read_chunk_matrix_coordinate(chunk, header, line_num, handler, options);
             } else {
-                line_num = read_chunk_vector_coordinate(chunk, header, line_num, handler);
+                line_num = read_chunk_vector_coordinate(chunk, header, line_num, handler, options);
             }
         }
 

--- a/include/fast_matrix_market/read_body_threads.hpp
+++ b/include/fast_matrix_market/read_body_threads.hpp
@@ -114,7 +114,7 @@ namespace fast_matrix_market {
                 }));
             } else {
                 parse_futures.push(pool.submit([=]() mutable {
-                    read_chunk_vector_coordinate(lcr.chunk, header, lcr.chunk_line_start, chunk_handler);
+                    read_chunk_vector_coordinate(lcr.chunk, header, lcr.chunk_line_start, chunk_handler, options);
                 }));
             }
         }

--- a/include/fast_matrix_market/types.hpp
+++ b/include/fast_matrix_market/types.hpp
@@ -67,4 +67,74 @@ namespace fast_matrix_market {
         int64_t header_line_count = 1;
     };
 
+    enum storage_order {row_major = 1, col_major = 2};
+    enum out_of_range_behavior {BestMatch = 1, ThrowOutOfRange = 2};
+
+    struct read_options {
+        /**
+         * Chunk size for the parsing step, in bytes.
+         */
+        int64_t chunk_size_bytes = 2 << 20;
+
+        /**
+         * If true then any symmetries other than general are expanded out.
+         * For any symmetries other than general, only entries in the lower triangular portion need be supplied.
+         * symmetric: for (row, column, value), also generate (column, row, value) except if row==column
+         * skew-symmetric: for (row, column, value), also generate (column, row, -value) except if row==column
+         * hermitian: for (row, column, value), also generate (column, row, complex_conjugate(value)) except if row==column
+         */
+        bool generalize_symmetry = true;
+
+        /**
+         * Generalize Symmetry:
+         * How to handle a value on the diagonal of a symmetric coordinate matrix.
+         *  - DuplicateElement: Duplicate the diagonal element
+         *  - ExtraZeroElement: emit a zero along with the diagonal element. The zero will appear first.
+         *
+         *  The extra cannot simply be omitted because the handlers work by setting already-allocated memory. This
+         *  is necessary for efficient parallelization.
+         *
+         *  This value is ignored if the parse handler has the kAppending flag set. In that case only a single
+         *  diagonal element is emitted.
+         */
+        enum {ExtraZeroElement, DuplicateElement} generalize_coordinate_diagnonal_values = ExtraZeroElement;
+
+        /**
+         * Whether or not parallel implementation is allowed.
+         */
+        bool parallel_ok = true;
+
+        /**
+         * Number of threads to use. 0 means std::thread::hardware_concurrency().
+         */
+        int num_threads = 0;
+
+        /**
+         * How to handle floating-point values that do not fit into their declared type.
+         * For example, parsing 1e9999 will
+         *  - BestMatch: return Infinity
+         *  - ThrowOutOfRange: throw out_of_range exception
+         */
+        out_of_range_behavior float_out_of_range_behavior = BestMatch;
+    };
+
+    struct write_options {
+        int64_t chunk_size_values = 2 << 12;
+
+        /**
+         * Whether or not parallel implementation is allowed.
+         */
+        bool parallel_ok = true;
+
+        /**
+         * Number of threads to use. 0 means std::thread::hardware_concurrency().
+         */
+        int num_threads = 0;
+
+        /**
+         * Floating-point formatting precision.
+         * Placeholder. Currently not used due to the various supported float rendering backends.
+         */
+        int precision = -1;
+    };
 }

--- a/python/tests/test_header.py
+++ b/python/tests/test_header.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import fast_matrix_market as fmm
 
 matrices = Path("matrices")
+cpp_matrices = matrices / ".." / ".." / ".." / "tests" / "matrices"
 
 
 class TestHeader(unittest.TestCase):
@@ -71,6 +72,14 @@ class TestHeader(unittest.TestCase):
 
         h2 = fmm.read_header(StringIO(s))
         self.assertEqual(h.to_dict(), h2.to_dict())
+
+    def test_header_overflow(self):
+        with self.assertRaises(OverflowError):
+            fmm.mmread(cpp_matrices / "overflow" / "overflow_dim_gt_int64.mtx")
+
+    def test_index_overflow(self):
+        with self.assertRaises(OverflowError):
+            fmm.mmread(cpp_matrices / "overflow" / "overflow_index_gt_int64.mtx")
 
 
 if __name__ == '__main__':

--- a/python/tests/test_scipy.py
+++ b/python/tests/test_scipy.py
@@ -283,6 +283,25 @@ class TestSciPy(unittest.TestCase):
                     m2 = fmm.mmread(StringIO(fmms))
                     self.assertAlmostEqual(m2[0][0], float('%%.%dg' % precision % value))
 
+    def test_value_overflow(self):
+        with self.subTest("integer"):
+            with self.assertRaises(OverflowError):
+                # SciPy throws OverflowError for integer values larger than 64-bit
+                fmm.mmread(cpp_matrices / "overflow" / "overflow_value_gt_int64.mtx")
+
+            # values larger than 32-bit do not throw
+            fmm.mmread(cpp_matrices / "overflow" / "overflow_value_gt_int32.mtx")
+
+        with self.subTest("float"):
+            # Python floating-point returns closest match on overflow, matching strtod() behavior if ERANGE is ignored
+            m = fmm.mmread(cpp_matrices / "overflow" / "overflow_value_gt_float128.mtx")
+            self.assertEqual(m.data[0], float("inf"))
+
+        with self.subTest("complex"):
+            m = fmm.mmread(cpp_matrices / "overflow" / "overflow_value_gt_complex128.mtx")
+            self.assertEqual(m.data[-1].real, float("inf"))
+            self.assertEqual(m.data[-1].imag, float("inf"))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -205,6 +205,42 @@ TEST_P(InvalidSuite, Small) {
 INSTANTIATE_TEST_SUITE_P(Invalid, InvalidSuite, testing::ValuesIn(InvalidSuite::get_invalid_matrix_files()));
 
 /**
+ * Overflow
+ */
+TEST(OverflowSuite, Small) {
+    triplet_matrix<int8_t, double> triplet_8d;
+    EXPECT_THROW(read_triplet_file("overflow/overflow_index_gt_int8.mtx", triplet_8d), fast_matrix_market::out_of_range);
+
+    fast_matrix_market::read_options best_match_options{};
+    fast_matrix_market::read_options throw_options{};
+    throw_options.float_out_of_range_behavior = fast_matrix_market::ThrowOutOfRange;
+    triplet_matrix<int64_t, float> triplet_lf;
+    EXPECT_THROW(read_triplet_file("overflow/overflow_value_gt_float64.mtx", triplet_lf, throw_options), fast_matrix_market::out_of_range);
+    EXPECT_NO_THROW(read_triplet_file("overflow/overflow_value_gt_float64.mtx", triplet_lf, best_match_options));
+
+    triplet_matrix<int64_t, double> triplet_ld;
+    EXPECT_THROW(read_triplet_file("overflow/overflow_value_gt_float64.mtx", triplet_ld, throw_options), fast_matrix_market::out_of_range);
+    EXPECT_NO_THROW(read_triplet_file("overflow/overflow_value_gt_float64.mtx", triplet_ld, best_match_options));
+
+    triplet_matrix<int64_t, long double> triplet_l_ld;
+    EXPECT_THROW(read_triplet_file("overflow/overflow_value_gt_float128.mtx", triplet_l_ld, throw_options), fast_matrix_market::out_of_range);
+    EXPECT_NO_THROW(read_triplet_file("overflow/overflow_value_gt_float128.mtx", triplet_l_ld, best_match_options));
+
+    triplet_matrix<int64_t, std::complex<double>> triplet_lc;
+    EXPECT_THROW(read_triplet_file("overflow/overflow_value_gt_complex128.mtx", triplet_lc, throw_options), fast_matrix_market::out_of_range);
+    EXPECT_NO_THROW(read_triplet_file("overflow/overflow_value_gt_complex128.mtx", triplet_lc, best_match_options));
+
+    triplet_matrix<int64_t, int64_t> triplet_l64;
+    EXPECT_THROW(read_triplet_file("overflow/overflow_value_gt_int64.mtx", triplet_l64), fast_matrix_market::out_of_range);
+
+    triplet_matrix<int64_t, int32_t> triplet_l32;
+    EXPECT_THROW(read_triplet_file("overflow/overflow_value_gt_int32.mtx", triplet_l32), fast_matrix_market::out_of_range);
+
+    triplet_matrix<int64_t, int8_t> triplet_l8;
+    EXPECT_THROW(read_triplet_file("overflow/overflow_value_gt_int32.mtx", triplet_l8), fast_matrix_market::out_of_range);
+}
+
+/**
  * Very basic tests: Triplet
  */
 template <typename MAT>

--- a/tests/field_conv_test.cpp
+++ b/tests/field_conv_test.cpp
@@ -147,3 +147,159 @@ TEST(LongDoubleSuite, Basic) {
     parse(fmm::value_to_string_fallback(val, 4), val2);
     EXPECT_FALSE(almost_equal(val, val2, 1E-6));
 }
+
+////////////
+///  Test reading integers
+////////////
+
+template <typename T>
+class ReadInt : public testing::Test {
+    T ignored = 0;
+};
+using ReadIntTypes = ::testing::Types<int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t>;
+TYPED_TEST_SUITE(ReadInt, ReadIntTypes);
+
+TYPED_TEST(ReadInt, Integer) {
+    TypeParam i;
+
+    std::string eight("8");
+    std::string invalid("asdf");
+
+#ifdef FMM_FROM_CHARS_INT_SUPPORTED
+    EXPECT_THROW(fmm::read_int_from_chars(invalid.c_str(), invalid.c_str() + invalid.size(), i), fmm::invalid_mm);
+    fmm::read_int_from_chars(eight.c_str(), eight.c_str() + eight.size(), i);
+    EXPECT_EQ(i, 8);
+#endif
+
+    EXPECT_THROW(fmm::read_int_fallback(invalid.c_str(), invalid.c_str() + invalid.size(), i), fmm::invalid_mm);
+    fmm::read_int_fallback(eight.c_str(), eight.c_str() + eight.size(), i);
+    EXPECT_EQ(i, 8);
+
+    EXPECT_THROW(fmm::read_int(invalid.c_str(), invalid.c_str() + invalid.size(), i), fmm::invalid_mm);
+    fmm::read_int(eight.c_str(), eight.c_str() + eight.size(), i);
+    EXPECT_EQ(i, 8);
+}
+
+TEST(ReadOverflow, Integer) {
+    int8_t i8;
+    int32_t i32;
+    int64_t i64;
+
+    std::string over_8("257");
+    std::string over_64("19223372036854775808");
+
+#ifdef FMM_FROM_CHARS_INT_SUPPORTED
+    EXPECT_THROW(fmm::read_int_from_chars(over_8.c_str(), over_8.c_str() + over_8.size(), i8), fmm::out_of_range);
+    EXPECT_THROW(fmm::read_int_from_chars(over_64.c_str(), over_64.c_str() + over_64.size(), i32), fmm::out_of_range);
+    EXPECT_THROW(fmm::read_int_from_chars(over_64.c_str(), over_64.c_str() + over_64.size(), i64), fmm::out_of_range);
+#endif
+
+    EXPECT_THROW(fmm::read_int_fallback(over_8.c_str(), over_8.c_str() + over_8.size(), i8), fmm::out_of_range);
+    EXPECT_THROW(fmm::read_int_fallback(over_64.c_str(), over_64.c_str() + over_64.size(), i32), fmm::out_of_range);
+    EXPECT_THROW(fmm::read_int_fallback(over_64.c_str(), over_64.c_str() + over_64.size(), i64), fmm::out_of_range);
+
+    EXPECT_THROW(fmm::read_int(over_8.c_str(), over_8.c_str() + over_8.size(), i8), fmm::out_of_range);
+    EXPECT_THROW(fmm::read_int(over_64.c_str(), over_64.c_str() + over_64.size(), i32), fmm::out_of_range);
+    EXPECT_THROW(fmm::read_int(over_64.c_str(), over_64.c_str() + over_64.size(), i64), fmm::out_of_range);
+}
+
+
+////////////
+///  Test reading floating-point
+////////////
+
+template <typename T>
+class ReadFloat : public testing::Test {
+    T ignored = 0;
+};
+using ReadFloatTypes = ::testing::Types<float, double>;
+TYPED_TEST_SUITE(ReadFloat, ReadFloatTypes);
+
+TYPED_TEST(ReadFloat, Float) {
+    TypeParam f;
+
+    std::string eight("8");
+    std::string invalid("asdf");
+
+#ifdef FMM_USE_FAST_FLOAT
+    EXPECT_THROW(fmm::read_float_fast_float(invalid.c_str(), invalid.c_str() + invalid.size(), f, fast_matrix_market::ThrowOutOfRange), fmm::invalid_mm);
+    fmm::read_float_fast_float(eight.c_str(), eight.c_str() + eight.size(), f, fast_matrix_market::ThrowOutOfRange);
+    EXPECT_EQ(f, 8);
+#endif
+
+#ifdef FMM_FROM_CHARS_DOUBLE_SUPPORTED
+    EXPECT_THROW(fmm::read_float_from_chars(invalid.c_str(), invalid.c_str() + invalid.size(), f, fast_matrix_market::ThrowOutOfRange), fmm::invalid_mm);
+    fmm::read_float_from_chars(eight.c_str(), eight.c_str() + eight.size(), f, fast_matrix_market::ThrowOutOfRange);
+    EXPECT_EQ(f, 8);
+#endif
+
+    EXPECT_THROW(fmm::read_float_fallback(invalid.c_str(), invalid.c_str() + invalid.size(), f, fast_matrix_market::ThrowOutOfRange), fmm::invalid_mm);
+    fmm::read_float_fallback(eight.c_str(), eight.c_str() + eight.size(), f, fast_matrix_market::ThrowOutOfRange);
+    EXPECT_EQ(f, 8);
+
+    EXPECT_THROW(fmm::read_float(invalid.c_str(), invalid.c_str() + invalid.size(), f, fast_matrix_market::ThrowOutOfRange), fmm::invalid_mm);
+    fmm::read_float(eight.c_str(), eight.c_str() + eight.size(), f, fast_matrix_market::ThrowOutOfRange);
+    EXPECT_EQ(f, 8);
+}
+
+TEST(ReadFloat, LongDouble) {
+    long double f;
+
+    std::string eight("8");
+    std::string invalid("asdf");
+
+#ifdef FMM_FROM_CHARS_LONG_DOUBLE_SUPPORTED
+    EXPECT_THROW(fmm::read_float_from_chars(invalid.c_str(), invalid.c_str() + invalid.size(), f, fast_matrix_market::ThrowOutOfRange), fmm::invalid_mm);
+    fmm::read_float_from_chars(eight.c_str(), eight.c_str() + eight.size(), f, fast_matrix_market::ThrowOutOfRange);
+    EXPECT_EQ(f, 8);
+#endif
+
+    EXPECT_THROW(fmm::read_float_fallback(invalid.c_str(), invalid.c_str() + invalid.size(), f, fast_matrix_market::ThrowOutOfRange), fmm::invalid_mm);
+    fmm::read_float_fallback(eight.c_str(), eight.c_str() + eight.size(), f, fast_matrix_market::ThrowOutOfRange);
+    EXPECT_EQ(f, 8);
+
+    EXPECT_THROW(fmm::read_float(invalid.c_str(), invalid.c_str() + invalid.size(), f, fast_matrix_market::ThrowOutOfRange), fmm::invalid_mm);
+    fmm::read_float(eight.c_str(), eight.c_str() + eight.size(), f, fast_matrix_market::ThrowOutOfRange);
+    EXPECT_EQ(f, 8);
+}
+
+TEST(ReadOverflow, Float) {
+    float f = -1;
+    double d = -1;
+    long double ld = -1;
+
+    std::string over_ld("1e99999");
+
+#ifdef FMM_USE_FAST_FLOAT
+    EXPECT_THROW(fmm::read_float_fast_float(over_ld.c_str(), over_ld.c_str() + over_ld.size(), f, fast_matrix_market::ThrowOutOfRange), fmm::out_of_range);
+    EXPECT_THROW(fmm::read_float_fast_float(over_ld.c_str(), over_ld.c_str() + over_ld.size(), d, fast_matrix_market::ThrowOutOfRange), fmm::out_of_range);
+
+    fmm::read_float_fast_float(over_ld.c_str(), over_ld.c_str() + over_ld.size(), f, fast_matrix_market::BestMatch);
+    EXPECT_EQ(std::numeric_limits<float>::infinity(), f);
+
+    fmm::read_float_fast_float(over_ld.c_str(), over_ld.c_str() + over_ld.size(), d, fast_matrix_market::BestMatch);
+    EXPECT_EQ(std::numeric_limits<double>::infinity(), d);
+
+#endif
+
+#ifdef FMM_FROM_CHARS_DOUBLE_SUPPORTED
+    EXPECT_THROW(fmm::read_float_from_chars(over_ld.c_str(), over_ld.c_str() + over_ld.size(), f, fast_matrix_market::ThrowOutOfRange), fmm::out_of_range);
+    EXPECT_THROW(fmm::read_float_from_chars(over_ld.c_str(), over_ld.c_str() + over_ld.size(), d, fast_matrix_market::ThrowOutOfRange), fmm::out_of_range);
+
+    fmm::read_float_from_chars(over_ld.c_str(), over_ld.c_str() + over_ld.size(), f, fast_matrix_market::BestMatch);
+    EXPECT_EQ(std::numeric_limits<float>::infinity(), f);
+
+    fmm::read_float_from_chars(over_ld.c_str(), over_ld.c_str() + over_ld.size(), d, fast_matrix_market::BestMatch);
+    EXPECT_EQ(std::numeric_limits<double>::infinity(), d);
+#endif
+#ifdef FMM_FROM_CHARS_LONG_DOUBLE_SUPPORTED
+    EXPECT_THROW(fmm::read_float_from_chars(over_ld.c_str(), over_ld.c_str() + over_ld.size(), ld, fast_matrix_market::ThrowOutOfRange), fmm::out_of_range);
+
+    fmm::read_float_from_chars(over_ld.c_str(), over_ld.c_str() + over_ld.size(), ld, fast_matrix_market::BestMatch);
+    EXPECT_EQ(std::numeric_limits<long double>::infinity(), ld);
+#endif
+
+    EXPECT_THROW(fmm::read_float_fallback(over_ld.c_str(), over_ld.c_str() + over_ld.size(), f, fast_matrix_market::ThrowOutOfRange), fmm::out_of_range);
+    EXPECT_THROW(fmm::read_float_fallback(over_ld.c_str(), over_ld.c_str() + over_ld.size(), d, fast_matrix_market::ThrowOutOfRange), fmm::out_of_range);
+    EXPECT_THROW(fmm::read_float_fallback(over_ld.c_str(), over_ld.c_str() + over_ld.size(), ld, fast_matrix_market::ThrowOutOfRange), fmm::out_of_range);
+}

--- a/tests/matrices/overflow/overflow_dim_gt_int64.mtx
+++ b/tests/matrices/overflow/overflow_dim_gt_int64.mtx
@@ -1,0 +1,3 @@
+%%MatrixMarket matrix coordinate integer general
+19223372036854775808 1 1
+1 1 1

--- a/tests/matrices/overflow/overflow_index_gt_int64.mtx
+++ b/tests/matrices/overflow/overflow_index_gt_int64.mtx
@@ -1,0 +1,6 @@
+%%MatrixMarket matrix coordinate real general
+% Matrix with indices that overflow an int64.
+% This matrix is also invalid because the index value is greater than the declared dimension,
+% but is intended to test the index parser.
+1000 1000 1
+19223372036854775808 1 1

--- a/tests/matrices/overflow/overflow_index_gt_int8.mtx
+++ b/tests/matrices/overflow/overflow_index_gt_int8.mtx
@@ -1,0 +1,4 @@
+%%MatrixMarket matrix coordinate real general
+% matrix with indices that overflow an int8
+1000 1000 1
+300 1 1

--- a/tests/matrices/overflow/overflow_value_gt_complex128.mtx
+++ b/tests/matrices/overflow/overflow_value_gt_complex128.mtx
@@ -1,0 +1,6 @@
+%%MatrixMarket matrix coordinate complex general
+% matrix with values that overflow a 128-bit float
+3 3 3
+2 2 1 1E9999
+3 3 1E9999 0
+1 1 1E9999 1E9999

--- a/tests/matrices/overflow/overflow_value_gt_float128.mtx
+++ b/tests/matrices/overflow/overflow_value_gt_float128.mtx
@@ -1,0 +1,4 @@
+%%MatrixMarket matrix coordinate real general
+% matrix with a value that overflows a 128-bit float
+3 3 1
+3 3 1E9999

--- a/tests/matrices/overflow/overflow_value_gt_float64.mtx
+++ b/tests/matrices/overflow/overflow_value_gt_float64.mtx
@@ -1,0 +1,4 @@
+%%MatrixMarket matrix coordinate real general
+% matrix with a value that overflows a 64-bit float but not an 80-bit float
+3 3 1
+3 3 1E310

--- a/tests/matrices/overflow/overflow_value_gt_int32.mtx
+++ b/tests/matrices/overflow/overflow_value_gt_int32.mtx
@@ -1,0 +1,4 @@
+%%MatrixMarket matrix coordinate integer general
+% matrix with a value that overflows an int64
+3 3 1
+2 2 8589934592

--- a/tests/matrices/overflow/overflow_value_gt_int64.mtx
+++ b/tests/matrices/overflow/overflow_value_gt_int64.mtx
@@ -1,0 +1,6 @@
+%%MatrixMarket matrix coordinate integer general
+% 3-by-3 matrix with values that overflow an int64
+3 3 3
+1 1 1
+2 2 2147483648
+3 3 19223372036854775808

--- a/tests/user_type_test.cpp
+++ b/tests/user_type_test.cpp
@@ -23,7 +23,7 @@ namespace fast_matrix_market {
      * @param out out parameter of parsed value
      * @return a pointer to the next character following the value. Likely the newline.
      */
-    const char *read_value(const char *pos, const char *end, std::string &out) {
+    const char *read_value(const char *pos, const char *end, std::string &out, [[maybe_unused]] const read_options& options = {}) {
         while (pos != end && *pos != '\n') {
             out += *pos;
             ++pos;


### PR DESCRIPTION
Strings with out-of-range integer values now throw an out_of_range exception. Floats optionally throw the same exception or return the closest match (+/-inf for overflow, +/-0 for underflow) as is the default behavior for strtod if one ignores errno==ERANGE. The latter is Python and SciPy behavior.

Fixes https://github.com/alugowski/fast_matrix_market/issues/11