### PR TITLE
Ensure skew-symmetric matrices are not loaded into an unsigned type

### DIFF
--- a/include/fast_matrix_market/read_body.hpp
+++ b/include/fast_matrix_market/read_body.hpp
@@ -133,7 +133,11 @@ namespace fast_matrix_market {
                                 handler.handle(col - 1, row - 1, value);
                                 break;
                             case skew_symmetric:
-                                handler.handle(col - 1, row - 1, negate(value));
+                                if constexpr (!std::is_unsigned_v<typename HANDLER::value_type>) {
+                                    handler.handle(col - 1, row - 1, negate(value));
+                                } else {
+                                    throw invalid_argument("Cannot load skew-symmetric matrix into unsigned value type.");
+                                }
                                 break;
                             case hermitian:
                                 handler.handle(col - 1, row - 1, complex_conjugate(value));
@@ -251,7 +255,11 @@ namespace fast_matrix_market {
                             handler.handle(col, row, value);
                             break;
                         case skew_symmetric:
-                            handler.handle(col, row, negate(value));
+                            if constexpr (!std::is_unsigned_v<typename HANDLER::value_type>) {
+                                handler.handle(col, row, negate(value));
+                            } else {
+                                throw invalid_argument("Cannot load skew-symmetric matrix into unsigned value type.");
+                            }
                             break;
                         case hermitian:
                             handler.handle(col, row, complex_conjugate(value));

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -596,6 +596,14 @@ INSTANTIATE_TEST_SUITE_P(SymmetrySuite, SymmetrySuite, testing::ValuesIn(Symmetr
 INSTANTIATE_TEST_SUITE_P(TripletLoadsArray, SymmetryTripletArraySuite, testing::ValuesIn(SymmetrySuite::get_array_symmetry_problems()));
 INSTANTIATE_TEST_SUITE_P(Array, SymmetryArraySuite, testing::ValuesIn(SymmetrySuite::get_array_symmetry_problems()));
 
+TEST(SymmetrySuite, TypeValidity) {
+    // Cannot load skew-symmetric matrices into an unsigned type.
+    triplet_matrix<int64_t, uint64_t> unsigned_triplet;
+    array_matrix<uint64_t> unsigned_array;
+    EXPECT_THROW(read_triplet_file("symmetry/coordinate_skew_symmetric_row.mtx", unsigned_triplet), fast_matrix_market::invalid_argument);
+    EXPECT_THROW(read_array_file("symmetry_array/array_skew-symmetric.mtx", unsigned_array), fast_matrix_market::invalid_argument);
+}
+
 TEST(Whitespace, Whitespace) {
     triplet_matrix<int64_t, double> expected, mat;
     read_triplet_file("nist_ex1.mtx", expected);


### PR DESCRIPTION
skew-symmetric negates values which causes incorrect values on unsigned types.