### PR TITLE
Adding GraphBLAS to Ubuntu CI Runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,63 +15,67 @@ jobs:
         python-version: ["3.7", "3.11"]
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-# The GraphBLAS that is in the Ubuntu repos is so old it doesn't even have GrB_Scalar.
-#    - name: Install GraphBLAS (Ubuntu)
-#      if: contains(matrix.os, 'ubuntu')
-#        # install suitesparse-dev which installs GraphBLAS.h and libgraphblas.a and .so
-#        # These are very old, so disable all the fun features.
-#      run: |
-#        sudo apt-get install -y libsuitesparse-dev
-#        echo "FMM_CMAKE_FLAGS=-DFMM_NO_GXB=ON" >> $GITHUB_ENV
+      - name: Install GraphBLAS (ubuntu)
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          mkdir -p grb
+          cd grb
+          wget --quiet https://anaconda.org/conda-forge/graphblas/7.4.4/download/linux-64/graphblas-7.4.4-hcb278e6_0.conda
+          unzip graphblas-7.4.4-hcb278e6_0.conda
+          tar xvf pkg-graphblas-7.4.4-hcb278e6_0.tar.zst
+          cd ..
+          echo "FMM_CMAKE_FLAGS=-DCMAKE_MODULE_PATH=${{ github.workspace }}/grb/lib/cmake/SuiteSparse -DGraphBLAS_ROOT=${{ github.workspace }}/grb/" >> $GITHUB_ENV
 
-    - name: Install GraphBLAS (macOS)
-      if: contains(matrix.os, 'macos')
-        # install suite-sparse which includes GraphBLAS and also FindGraphBLAS.cmake
-      run: brew install suite-sparse
+      - name: Install GraphBLAS (macOS)
+        if:
+          contains(matrix.os, 'macos')
+          # install suite-sparse which includes GraphBLAS and also FindGraphBLAS.cmake
+        run: brew install suite-sparse
 
-    - name: Configure
-      run: |
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DFAST_MATRIX_MARKET_TEST=ON -DFAST_MATRIX_MARKET_TEST_COVERAGE=ON ${{ env.FMM_CMAKE_FLAGS }}
+      - name: Configure
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DFAST_MATRIX_MARKET_TEST=ON -DFAST_MATRIX_MARKET_TEST_COVERAGE=ON ${{ env.FMM_CMAKE_FLAGS }}
 
-    - name: Build
-      run: |
-        cmake --build build --config Debug
+      - name: Build
+        run: |
+          cmake --build build --config Debug
 
-    - name: Test
-      run: |
-        cd build
-        ctest -C Debug --output-on-failure --verbose
+      - name: Test
+        run: |
+          cd build
+          ctest -C Debug --output-on-failure --verbose
 
-    - name: Python Build and Install
-        # On some platforms pip uses a temporary build directory but only copies the python/ directory there.
-        # This breaks the relative symbolic links to the C++ library. Workaround is to pass the checkout directory
-        # as an environment variable so CMakeLists.txt can read it and know where to import the C++ library from.
-      run: |
-        export FMM_PYTHON_DIR="$(pwd)" && pip install python/.[test] -v
-      shell: bash
+      - name:
+          Python Build and Install
+          # On some platforms pip uses a temporary build directory but only copies the python/ directory there.
+          # This breaks the relative symbolic links to the C++ library. Workaround is to pass the checkout directory
+          # as an environment variable so CMakeLists.txt can read it and know where to import the C++ library from.
+        run: |
+          export FMM_PYTHON_DIR="$(pwd)" && pip install python/.[test] -v
+        shell: bash
 
-    - name: Python Test
-      run: |
-        cd python/tests
-        pytest
+      - name: Python Test
+        run: |
+          cd python/tests
+          pytest
 
-    - name: Python Test with Coverage
-      if: contains(matrix.os, 'ubuntu')
-      run: |
-        pip install pytest-cov
-        cd python/tests
-        pytest --cov=fast_matrix_market --cov-report term --cov-report=xml
+      - name: Python Test with Coverage
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          pip install pytest-cov
+          cd python/tests
+          pytest --cov=fast_matrix_market --cov-report term --cov-report=xml
 
-    - name: Upload Coverage to Codecov
-      if: contains(matrix.os, 'ubuntu')
-      uses: codecov/codecov-action@v3
-      with:
-        gcov: true
-        gcov_include: include/*   # C++ coverage
+      - name: Upload Coverage to Codecov
+        if: contains(matrix.os, 'ubuntu')
+        uses: codecov/codecov-action@v3
+        with:
+          gcov: true
+          gcov_include: include/* # C++ coverage
 #        directory: python/tests   # Python coverage. This seems to confuse codecov, disable for now.


### PR DESCRIPTION
# General

Hi @alugowski, thanks for putting this package together! I noticed [your comments](https://github.com/alugowski/fast_matrix_market/blob/6b84f7a96ffbddf1d01bc642619ddb732a33e49b/.github/workflows/tests.yml#L28) on your workflow about installing GraphBLAS on Ubuntu and wanted to suggest an alternative method for installation that's used by several of the GraphBLAS authors in the LAGraph project.

# Details

Most of my changes are adapted from the[ CI workflow used by LAGraph](https://github.com/GraphBLAS/LAGraph/blob/102bd15a0f842b7e3d8d2f2eed5b4728fd5811c9/.github/workflows/build.yml#L20-L31).  The GraphBLAS authors update the conda-forge regularly with binary releases you can pull into CI with just a `wget` command. You could use this same strategy for other operating systems too and I'm happy to add those to this PR if you're interested.

# Next Steps
Happy to discuss any comments/questions/suggestions, just let me know!