### PR TITLE
GraphBLAS binding: sum duplicates

### DIFF
--- a/README.GraphBLAS.md
+++ b/README.GraphBLAS.md
@@ -35,6 +35,8 @@ fast_matrix_market::read_matrix_market_graphblas(f, &A);
 
 User types are not supported at this time. If you have a use case for user types stored in Matrix Market please get in touch.
 
+**Duplicate values** are summed using `GrB_PLUS_*`.
+
 **Note:** if `A` is a `GrB_Vector` then the Matrix Market file must be either a `vector` or a
 1-by-N row or M-by-1 column matrix. Any other matrix will cause an exception to be thrown.
 

--- a/include/fast_matrix_market/app/GraphBLAS.hpp
+++ b/include/fast_matrix_market/app/GraphBLAS.hpp
@@ -177,7 +177,7 @@ namespace fast_matrix_market {
         static GrB_Type type() { return GrB_BOOL; }
 
         static GrB_Info build_matrix(GrB_Matrix mat, const GrB_Index* rows, const GrB_Index* cols, const bool* vals, GrB_Index nvals) {
-            return GrB_Matrix_build_BOOL(mat, rows, cols, vals, nvals, nullptr);
+            return GrB_Matrix_build_BOOL(mat, rows, cols, vals, nvals, GrB_PLUS_BOOL);
         }
 
         static GrB_Info set_element(GrB_Scalar scalar, bool x) {
@@ -194,7 +194,7 @@ namespace fast_matrix_market {
         }
 #endif
         static GrB_Info build_vector(GrB_Vector vec, const GrB_Index* indices, const bool* vals, GrB_Index nvals) {
-            return GrB_Vector_build_BOOL(vec, indices, vals, nvals, nullptr);
+            return GrB_Vector_build_BOOL(vec, indices, vals, nvals, GrB_PLUS_BOOL);
         }
 
         static GrB_Info GrB_Vector_extractTuples(GrB_Index *I, bool *X, GrB_Index *nvals, const GrB_Vector& A) {
@@ -205,7 +205,7 @@ namespace fast_matrix_market {
         static GrB_Type type() { return GrB_INT8; }
 
         static GrB_Info build_matrix(GrB_Matrix mat, const GrB_Index* rows, const GrB_Index* cols, const int8_t* vals, GrB_Index nvals) {
-            return GrB_Matrix_build_INT8(mat, rows, cols, vals, nvals, nullptr);
+            return GrB_Matrix_build_INT8(mat, rows, cols, vals, nvals, GrB_PLUS_INT8);
         }
 
         static GrB_Info set_element(GrB_Scalar scalar, int8_t x) {
@@ -222,7 +222,7 @@ namespace fast_matrix_market {
         }
 #endif
         static GrB_Info build_vector(GrB_Vector vec, const GrB_Index* indices, const int8_t* vals, GrB_Index nvals) {
-            return GrB_Vector_build_INT8(vec, indices, vals, nvals, nullptr);
+            return GrB_Vector_build_INT8(vec, indices, vals, nvals, GrB_PLUS_INT8);
         }
 
         static GrB_Info GrB_Vector_extractTuples(GrB_Index *I, int8_t *X, GrB_Index *nvals, const GrB_Vector& A) {
@@ -233,7 +233,7 @@ namespace fast_matrix_market {
         static GrB_Type type() { return GrB_INT16; }
 
         static GrB_Info build_matrix(GrB_Matrix mat, const GrB_Index* rows, const GrB_Index* cols, const int16_t* vals, GrB_Index nvals) {
-            return GrB_Matrix_build_INT16(mat, rows, cols, vals, nvals, nullptr);
+            return GrB_Matrix_build_INT16(mat, rows, cols, vals, nvals, GrB_PLUS_INT16);
         }
 
         static GrB_Info set_element(GrB_Scalar scalar, int16_t x) {
@@ -250,7 +250,7 @@ namespace fast_matrix_market {
         }
 #endif
         static GrB_Info build_vector(GrB_Vector vec, const GrB_Index* indices, const int16_t* vals, GrB_Index nvals) {
-            return GrB_Vector_build_INT16(vec, indices, vals, nvals, nullptr);
+            return GrB_Vector_build_INT16(vec, indices, vals, nvals, GrB_PLUS_INT16);
         }
 
         static GrB_Info GrB_Vector_extractTuples(GrB_Index *I, int16_t *X, GrB_Index *nvals, const GrB_Vector& A) {
@@ -261,7 +261,7 @@ namespace fast_matrix_market {
         static GrB_Type type() { return GrB_INT32; }
 
         static GrB_Info build_matrix(GrB_Matrix mat, const GrB_Index* rows, const GrB_Index* cols, const int32_t* vals, GrB_Index nvals) {
-            return GrB_Matrix_build_INT32(mat, rows, cols, vals, nvals, nullptr);
+            return GrB_Matrix_build_INT32(mat, rows, cols, vals, nvals, GrB_PLUS_INT32);
         }
 
         static GrB_Info set_element(GrB_Scalar scalar, int32_t x) {
@@ -278,7 +278,7 @@ namespace fast_matrix_market {
         }
 #endif
         static GrB_Info build_vector(GrB_Vector vec, const GrB_Index* indices, const int32_t* vals, GrB_Index nvals) {
-            return GrB_Vector_build_INT32(vec, indices, vals, nvals, nullptr);
+            return GrB_Vector_build_INT32(vec, indices, vals, nvals, GrB_PLUS_INT32);
         }
 
         static GrB_Info GrB_Vector_extractTuples(GrB_Index *I, int32_t *X, GrB_Index *nvals, const GrB_Vector& A) {
@@ -289,7 +289,7 @@ namespace fast_matrix_market {
         static GrB_Type type() { return GrB_INT64; }
 
         static GrB_Info build_matrix(GrB_Matrix mat, const GrB_Index* rows, const GrB_Index* cols, const int64_t* vals, GrB_Index nvals) {
-            return GrB_Matrix_build_INT64(mat, rows, cols, vals, nvals, nullptr);
+            return GrB_Matrix_build_INT64(mat, rows, cols, vals, nvals, GrB_PLUS_INT64);
         }
 
         static GrB_Info set_element(GrB_Scalar scalar, int64_t x) {
@@ -306,7 +306,7 @@ namespace fast_matrix_market {
         }
 #endif
         static GrB_Info build_vector(GrB_Vector vec, const GrB_Index* indices, const int64_t* vals, GrB_Index nvals) {
-            return GrB_Vector_build_INT64(vec, indices, vals, nvals, nullptr);
+            return GrB_Vector_build_INT64(vec, indices, vals, nvals, GrB_PLUS_INT64);
         }
 
         static GrB_Info GrB_Vector_extractTuples(GrB_Index *I, int64_t *X, GrB_Index *nvals, const GrB_Vector& A) {
@@ -317,7 +317,7 @@ namespace fast_matrix_market {
         static GrB_Type type() { return GrB_UINT8; }
 
         static GrB_Info build_matrix(GrB_Matrix mat, const GrB_Index* rows, const GrB_Index* cols, const uint8_t* vals, GrB_Index nvals) {
-            return GrB_Matrix_build_UINT8(mat, rows, cols, vals, nvals, nullptr);
+            return GrB_Matrix_build_UINT8(mat, rows, cols, vals, nvals, GrB_PLUS_UINT8);
         }
 
         static GrB_Info set_element(GrB_Scalar scalar, uint8_t x) {
@@ -334,7 +334,7 @@ namespace fast_matrix_market {
         }
 #endif
         static GrB_Info build_vector(GrB_Vector vec, const GrB_Index* indices, const uint8_t* vals, GrB_Index nvals) {
-            return GrB_Vector_build_UINT8(vec, indices, vals, nvals, nullptr);
+            return GrB_Vector_build_UINT8(vec, indices, vals, nvals, GrB_PLUS_UINT8);
         }
 
         static GrB_Info GrB_Vector_extractTuples(GrB_Index *I, uint8_t *X, GrB_Index *nvals, const GrB_Vector& A) {
@@ -345,7 +345,7 @@ namespace fast_matrix_market {
         static GrB_Type type() { return GrB_UINT16; }
 
         static GrB_Info build_matrix(GrB_Matrix mat, const GrB_Index* rows, const GrB_Index* cols, const uint16_t* vals, GrB_Index nvals) {
-            return GrB_Matrix_build_UINT16(mat, rows, cols, vals, nvals, nullptr);
+            return GrB_Matrix_build_UINT16(mat, rows, cols, vals, nvals, GrB_PLUS_UINT16);
         }
 
         static GrB_Info set_element(GrB_Scalar scalar, uint16_t x) {
@@ -362,7 +362,7 @@ namespace fast_matrix_market {
         }
 #endif
         static GrB_Info build_vector(GrB_Vector vec, const GrB_Index* indices, const uint16_t* vals, GrB_Index nvals) {
-            return GrB_Vector_build_UINT16(vec, indices, vals, nvals, nullptr);
+            return GrB_Vector_build_UINT16(vec, indices, vals, nvals, GrB_PLUS_UINT16);
         }
 
         static GrB_Info GrB_Vector_extractTuples(GrB_Index *I, uint16_t *X, GrB_Index *nvals, const GrB_Vector& A) {
@@ -373,7 +373,7 @@ namespace fast_matrix_market {
         static GrB_Type type() { return GrB_UINT32; }
 
         static GrB_Info build_matrix(GrB_Matrix mat, const GrB_Index* rows, const GrB_Index* cols, const uint32_t* vals, GrB_Index nvals) {
-            return GrB_Matrix_build_UINT32(mat, rows, cols, vals, nvals, nullptr);
+            return GrB_Matrix_build_UINT32(mat, rows, cols, vals, nvals, GrB_PLUS_UINT32);
         }
 
         static GrB_Info set_element(GrB_Scalar scalar, uint32_t x) {
@@ -390,7 +390,7 @@ namespace fast_matrix_market {
         }
 #endif
         static GrB_Info build_vector(GrB_Vector vec, const GrB_Index* indices, const uint32_t* vals, GrB_Index nvals) {
-            return GrB_Vector_build_UINT32(vec, indices, vals, nvals, nullptr);
+            return GrB_Vector_build_UINT32(vec, indices, vals, nvals, GrB_PLUS_UINT32);
         }
 
         static GrB_Info GrB_Vector_extractTuples(GrB_Index *I, uint32_t *X, GrB_Index *nvals, const GrB_Vector& A) {
@@ -401,7 +401,7 @@ namespace fast_matrix_market {
         static GrB_Type type() { return GrB_UINT64; }
 
         static GrB_Info build_matrix(GrB_Matrix mat, const GrB_Index* rows, const GrB_Index* cols, const uint64_t* vals, GrB_Index nvals) {
-            return GrB_Matrix_build_UINT64(mat, rows, cols, vals, nvals, nullptr);
+            return GrB_Matrix_build_UINT64(mat, rows, cols, vals, nvals, GrB_PLUS_UINT64);
         }
 
         static GrB_Info set_element(GrB_Scalar scalar, uint64_t x) {
@@ -418,7 +418,7 @@ namespace fast_matrix_market {
         }
 #endif
         static GrB_Info build_vector(GrB_Vector vec, const GrB_Index* indices, const uint64_t* vals, GrB_Index nvals) {
-            return GrB_Vector_build_UINT64(vec, indices, vals, nvals, nullptr);
+            return GrB_Vector_build_UINT64(vec, indices, vals, nvals, GrB_PLUS_UINT64);
         }
 
         static GrB_Info GrB_Vector_extractTuples(GrB_Index *I, uint64_t *X, GrB_Index *nvals, const GrB_Vector& A) {
@@ -429,7 +429,7 @@ namespace fast_matrix_market {
         static GrB_Type type() { return GrB_FP32; }
 
         static GrB_Info build_matrix(GrB_Matrix mat, const GrB_Index* rows, const GrB_Index* cols, const float* vals, GrB_Index nvals) {
-            return GrB_Matrix_build_FP32(mat, rows, cols, vals, nvals, nullptr);
+            return GrB_Matrix_build_FP32(mat, rows, cols, vals, nvals, GrB_PLUS_FP32);
         }
 
         static GrB_Info set_element(GrB_Scalar scalar, float x) {
@@ -446,7 +446,7 @@ namespace fast_matrix_market {
         }
 #endif
         static GrB_Info build_vector(GrB_Vector vec, const GrB_Index* indices, const float* vals, GrB_Index nvals) {
-            return GrB_Vector_build_FP32(vec, indices, vals, nvals, nullptr);
+            return GrB_Vector_build_FP32(vec, indices, vals, nvals, GrB_PLUS_FP32);
         }
 
         static GrB_Info GrB_Vector_extractTuples(GrB_Index *I, float *X, GrB_Index *nvals, const GrB_Vector& A) {
@@ -457,7 +457,7 @@ namespace fast_matrix_market {
         static GrB_Type type() { return GrB_FP64; }
 
         static GrB_Info build_matrix(GrB_Matrix mat, const GrB_Index* rows, const GrB_Index* cols, const double* vals, GrB_Index nvals) {
-            return GrB_Matrix_build_FP64(mat, rows, cols, vals, nvals, nullptr);
+            return GrB_Matrix_build_FP64(mat, rows, cols, vals, nvals, GrB_PLUS_FP64);
         }
 
         static GrB_Info set_element(GrB_Scalar scalar, double x) {
@@ -474,7 +474,7 @@ namespace fast_matrix_market {
         }
 #endif
         static GrB_Info build_vector(GrB_Vector vec, const GrB_Index* indices, const double* vals, GrB_Index nvals) {
-            return GrB_Vector_build_FP64(vec, indices, vals, nvals, nullptr);
+            return GrB_Vector_build_FP64(vec, indices, vals, nvals, GrB_PLUS_FP64);
         }
 
         static GrB_Info GrB_Vector_extractTuples(GrB_Index *I, double *X, GrB_Index *nvals, const GrB_Vector& A) {
@@ -486,7 +486,7 @@ namespace fast_matrix_market {
         static GrB_Type type() { return GxB_FC32; }
 
         static GrB_Info build_matrix(GrB_Matrix mat, const GrB_Index* rows, const GrB_Index* cols, const std::complex<float>* vals, GrB_Index nvals) {
-            return GxB_Matrix_build_FC32(mat, rows, cols, vals, nvals, nullptr);
+            return GxB_Matrix_build_FC32(mat, rows, cols, vals, nvals, GxB_PLUS_FC32);
         }
 
         static GrB_Info set_element(GrB_Scalar scalar, const std::complex<float>& x) {
@@ -503,7 +503,7 @@ namespace fast_matrix_market {
         }
 #endif
         static GrB_Info build_vector(GrB_Vector vec, const GrB_Index* indices, const std::complex<float>* vals, GrB_Index nvals) {
-            return GxB_Vector_build_FC32(vec, indices, vals, nvals, nullptr);
+            return GxB_Vector_build_FC32(vec, indices, vals, nvals, GxB_PLUS_FC32);
         }
 
         static GrB_Info GrB_Vector_extractTuples(GrB_Index *I, std::complex<float> *X, GrB_Index *nvals, const GrB_Vector& A) {
@@ -514,7 +514,7 @@ namespace fast_matrix_market {
         static GrB_Type type() { return GxB_FC64; }
 
         static GrB_Info build_matrix(GrB_Matrix mat, const GrB_Index* rows, const GrB_Index* cols, const std::complex<double>* vals, GrB_Index nvals) {
-            return GxB_Matrix_build_FC64(mat, rows, cols, vals, nvals, nullptr);
+            return GxB_Matrix_build_FC64(mat, rows, cols, vals, nvals, GxB_PLUS_FC64);
         }
 
         static GrB_Info set_element(GrB_Scalar scalar, const std::complex<double>& x) {
@@ -531,7 +531,7 @@ namespace fast_matrix_market {
         }
 #endif
         static GrB_Info build_vector(GrB_Vector vec, const GrB_Index* indices, const std::complex<double>* vals, GrB_Index nvals) {
-            return GxB_Vector_build_FC64(vec, indices, vals, nvals, nullptr);
+            return GxB_Vector_build_FC64(vec, indices, vals, nvals, GxB_PLUS_FC64);
         }
 
         static GrB_Info GrB_Vector_extractTuples(GrB_Index *I, std::complex<double> *X, GrB_Index *nvals, const GrB_Vector& A) {

--- a/tests/graphblas_test.cpp
+++ b/tests/graphblas_test.cpp
@@ -313,6 +313,11 @@ public:
         {
             std::ifstream f(load_path);
             fast_matrix_market::read_header(f, header);
+
+            if (param.find("dupes") != std::string::npos) {
+                // test files that have duplicates only have one duplicate
+                num_dupes = 1;
+            }
         }
 
 #if FMM_GXB_COMPLEX
@@ -389,6 +394,9 @@ public:
             {"dcsc", dcsc},
             {"dcsr", dcsr},
     };
+
+    // number of duplicate elements in the original mtx file
+    int num_dupes = 0;
 };
 
 TEST_P(GraphBLASMatrixTest, SmallMatrices) {
@@ -407,7 +415,7 @@ TEST_P(GraphBLASMatrixTest, SmallMatrices) {
     for (const auto& [label, mat] : sparse_mats) {
         EXPECT_EQ(header.nrows, nrows(mat));
         EXPECT_EQ(header.ncols, ncols(mat));
-        EXPECT_EQ(header.nnz, nnz(mat));
+        EXPECT_EQ(header.nnz, nnz(mat) + num_dupes);
         EXPECT_TRUE(is_equal(full, mat));
 
         // compare to non-GraphBLAS array
@@ -445,9 +453,11 @@ INSTANTIATE_TEST_SUITE_P(
                 , "kepner_gilbert_graph.mtx"
                 , "vector_array.mtx"
                 , "vector_coordinate.mtx"
+                , "vector_coordinate_dupes.mtx"
                 , "eye3_pattern.mtx"
                 , "eye3_complex.mtx"
                 , "vector_coordinate_complex.mtx"
+                , "vector_coordinate_complex_dupes.mtx"
         ));
 
 // Test %%GraphBLAS type <ctype>
@@ -530,6 +540,8 @@ TEST(GraphBLASMatrixTest, Vector) {
             "vector_array.mtx"
             , "vector_coordinate.mtx"
             , "vector_coordinate_complex.mtx"
+            , "vector_coordinate_dupes.mtx"
+            , "vector_coordinate_complex_dupes.mtx"
     };
     for (auto param : filenames) {
         std::string load_path = kTestMatrixDir + param;

--- a/tests/matrices/graphblas/matrix_bool.mtx
+++ b/tests/matrices/graphblas/matrix_bool.mtx
@@ -1,6 +1,7 @@
 %%MatrixMarket matrix coordinate real general
 %%GraphBLAS type bool
-3 1 3
+3 1 4
 1 1 1
 2 1 1
+3 1 1
 3 1 1

--- a/tests/matrices/graphblas/matrix_double.mtx
+++ b/tests/matrices/graphblas/matrix_double.mtx
@@ -1,6 +1,7 @@
 %%MatrixMarket matrix coordinate real general
 %%GraphBLAS type double
-3 1 3
+3 1 4
 1 1 1
 2 1 1
+3 1 1
 3 1 1

--- a/tests/matrices/graphblas/matrix_double_complex.mtx
+++ b/tests/matrices/graphblas/matrix_double_complex.mtx
@@ -1,6 +1,7 @@
 %%MatrixMarket matrix coordinate complex general
 %%GraphBLAS type double complex
-3 1 3
+3 1 4
 1 1 1 0
 2 1 1 0
+3 1 1 0
 3 1 1 0

--- a/tests/matrices/graphblas/matrix_float.mtx
+++ b/tests/matrices/graphblas/matrix_float.mtx
@@ -1,6 +1,7 @@
 %%MatrixMarket matrix coordinate real general
 %%GraphBLAS type float
-3 1 3
+3 1 4
 1 1 1
 2 1 1
+3 1 1
 3 1 1

--- a/tests/matrices/graphblas/matrix_float_complex.mtx
+++ b/tests/matrices/graphblas/matrix_float_complex.mtx
@@ -1,6 +1,7 @@
 %%MatrixMarket matrix coordinate complex general
 %%GraphBLAS type float complex
-3 1 3
+3 1 4
 1 1 1 0
 2 1 1 0
+3 1 1 0
 3 1 1 0

--- a/tests/matrices/graphblas/matrix_int16.mtx
+++ b/tests/matrices/graphblas/matrix_int16.mtx
@@ -1,6 +1,7 @@
 %%MatrixMarket matrix coordinate real general
 %%GraphBLAS type int16_t
-3 1 3
+3 1 4
 1 1 1
 2 1 1
+3 1 1
 3 1 1

--- a/tests/matrices/graphblas/matrix_int32.mtx
+++ b/tests/matrices/graphblas/matrix_int32.mtx
@@ -1,6 +1,7 @@
 %%MatrixMarket matrix coordinate real general
 %%GraphBLAS type int32_t
-3 1 3
+3 1 4
 1 1 1
 2 1 1
+3 1 1
 3 1 1

--- a/tests/matrices/graphblas/matrix_int64.mtx
+++ b/tests/matrices/graphblas/matrix_int64.mtx
@@ -1,6 +1,7 @@
 %%MatrixMarket matrix coordinate real general
 %%GraphBLAS type int64_t
-3 1 3
+3 1 4
 1 1 1
 2 1 1
+3 1 1
 3 1 1

--- a/tests/matrices/graphblas/matrix_int8.mtx
+++ b/tests/matrices/graphblas/matrix_int8.mtx
@@ -1,6 +1,7 @@
 %%MatrixMarket matrix coordinate real general
 %%GraphBLAS type int8_t
-3 1 3
+3 1 4
 1 1 1
 2 1 1
+3 1 1
 3 1 1

--- a/tests/matrices/graphblas/matrix_uint16.mtx
+++ b/tests/matrices/graphblas/matrix_uint16.mtx
@@ -1,6 +1,7 @@
 %%MatrixMarket matrix coordinate real general
 %%GraphBLAS type uint16_t
-3 1 3
+3 1 4
 1 1 1
 2 1 1
+3 1 1
 3 1 1

--- a/tests/matrices/graphblas/matrix_uint32.mtx
+++ b/tests/matrices/graphblas/matrix_uint32.mtx
@@ -1,6 +1,7 @@
 %%MatrixMarket matrix coordinate real general
 %%GraphBLAS type uint32_t
-3 1 3
+3 1 4
 1 1 1
 2 1 1
+3 1 1
 3 1 1

--- a/tests/matrices/graphblas/matrix_uint64.mtx
+++ b/tests/matrices/graphblas/matrix_uint64.mtx
@@ -1,6 +1,7 @@
 %%MatrixMarket matrix coordinate real general
 %%GraphBLAS type uint64_t
-3 1 3
+3 1 4
 1 1 1
 2 1 1
+3 1 1
 3 1 1

--- a/tests/matrices/graphblas/matrix_uint8.mtx
+++ b/tests/matrices/graphblas/matrix_uint8.mtx
@@ -1,6 +1,7 @@
 %%MatrixMarket matrix coordinate real general
 %%GraphBLAS type uint8_t
-3 1 3
+3 1 4
 1 1 1
 2 1 1
+3 1 1
 3 1 1

--- a/tests/matrices/vector_coordinate_complex_dupes.mtx
+++ b/tests/matrices/vector_coordinate_complex_dupes.mtx
@@ -1,0 +1,6 @@
+%%MatrixMarket vector coordinate complex general
+4 4
+1 101 0
+2 202 1
+4 202 0
+4 202 0

--- a/tests/matrices/vector_coordinate_dupes.mtx
+++ b/tests/matrices/vector_coordinate_dupes.mtx
@@ -1,0 +1,6 @@
+%%MatrixMarket vector coordinate real general
+4 4
+1 101
+2 202
+4 202
+4 202


### PR DESCRIPTION
The previous nullptr argument for GrB_Matrix_build's `dup` argument would cause a GrB_INVALID_VALUE (-3) to be thrown if there are any duplicate values in the matrix market file. Use GrB_PLUS instead.