### PR TITLE
Include `std::string` user type in main header

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A fast and full-featured Matrix Market I/O library for C++ and [Python](python).
 
-Ready-to-use bindings for [GraphBLAS](README.GraphBLAS.md), [Eigen](README.Eigen.md), [CXSparse](README.CXSparse.md), [Blaze](README.Blaze.md), [Armadillo](README.Armadillo.md), [SciPy](python/README.md), `std::vector`.  
+Ready-to-use bindings for [GraphBLAS](README.GraphBLAS.md), [Eigen](README.Eigen.md), [CXSparse](README.CXSparse.md), [Blaze](README.Blaze.md), [Armadillo](README.Armadillo.md), [SciPy](python/README.md), `std::vector`-like.  
 Easy to integrate with any datastructure.
 
 [Matrix Market](https://math.nist.gov/MatrixMarket/formats.html) is a simple, human-readable, and widely used sparse matrix file format that looks like this:
@@ -58,7 +58,7 @@ Then simply run all the cells in the [benchmark_plots/plot.ipynb](benchmark_plot
 
   * Support all C++ types.
     * `float`, `double`, `long double`, `std::complex<>`, integer types, `bool`.
-    * Arbitrary types. [Example using `std::string`.](tests/user_type_test.cpp)
+    * Arbitrary types. `std::string` comes bundled. See [implementation](include/fast_matrix_market/app/user_type_string.hpp), [example usage](tests/user_type_test.cpp)
 
   * Automatic `std::complex` up-cast. For example, `real` files can be read into `std::complex<double>` arrays.
 

--- a/include/fast_matrix_market/app/Armadillo.hpp
+++ b/include/fast_matrix_market/app/Armadillo.hpp
@@ -88,7 +88,7 @@ namespace fast_matrix_market {
         header.nnz = m.n_nonzero;
 
         header.object = matrix;
-        if (header.field != pattern) {
+        if (header.field != pattern && options.fill_header_field_type) {
             header.field = get_field_type((const VT *) nullptr);
         }
         header.format = coordinate;

--- a/include/fast_matrix_market/app/Blaze.hpp
+++ b/include/fast_matrix_market/app/Blaze.hpp
@@ -348,7 +348,7 @@ namespace fast_matrix_market {
         header.nnz = (int64_t)indices.size();
 
         header.object = vector;
-        if (header.field != pattern) {
+        if (header.field != pattern && options.fill_header_field_type) {
             header.field = get_field_type((const VT*)nullptr);
         }
         header.format = coordinate;
@@ -381,7 +381,9 @@ namespace fast_matrix_market {
         header.nnz = vector_length;
 
         header.object = vector;
-        header.field = get_field_type((const VT *) nullptr);
+        if (options.fill_header_field_type) {
+            header.field = get_field_type((const VT *) nullptr);
+        }
         header.format = array;
 
         write_header(os, header, options);

--- a/include/fast_matrix_market/app/CXSparse.hpp
+++ b/include/fast_matrix_market/app/CXSparse.hpp
@@ -49,7 +49,7 @@ namespace fast_matrix_market {
         header.object = matrix;
         if (cs->x == nullptr) {
             header.field = pattern;
-        } else {
+        } else if (options.fill_header_field_type) {
             header.field = get_field_type(cs->x);
         }
         header.format = coordinate;

--- a/include/fast_matrix_market/app/Eigen.hpp
+++ b/include/fast_matrix_market/app/Eigen.hpp
@@ -153,7 +153,7 @@ namespace fast_matrix_market {
         header.nnz = mat.nonZeros();
 
         header.object = matrix;
-        if (header.field != pattern) {
+        if (header.field != pattern && options.fill_header_field_type) {
             header.field = get_field_type((const typename SparseType::Scalar*)nullptr);
         }
         header.format = coordinate;
@@ -178,7 +178,9 @@ namespace fast_matrix_market {
         header.nnz = mat.rows() * mat.cols();
 
         header.object = matrix;
-        header.field = get_field_type((const typename DenseType::Scalar*)nullptr);
+        if (options.fill_header_field_type) {
+            header.field = get_field_type((const typename DenseType::Scalar *) nullptr);
+        }
         header.format = array;
 
         write_header(os, header, options);

--- a/include/fast_matrix_market/app/GraphBLAS.hpp
+++ b/include/fast_matrix_market/app/GraphBLAS.hpp
@@ -1159,7 +1159,7 @@ namespace fast_matrix_market {
         }
 
         header.object = matrix;
-        if (header.field != pattern) {
+        if (header.field != pattern && options.fill_header_field_type) {
             header.field = get_field(type);
         }
         header.format = coordinate;
@@ -1386,7 +1386,7 @@ namespace fast_matrix_market {
         }
 
         header.object = vector;
-        if (header.field != pattern) {
+        if (header.field != pattern && options.fill_header_field_type) {
             header.field = get_field(type);
         }
         header.format = coordinate;

--- a/include/fast_matrix_market/app/array.hpp
+++ b/include/fast_matrix_market/app/array.hpp
@@ -105,7 +105,9 @@ namespace fast_matrix_market {
         header.nnz = values.size();
 
         header.object = matrix;
-        header.field = get_field_type((const VT*)nullptr);
+        if (options.fill_header_field_type) {
+            header.field = get_field_type((const VT *) nullptr);
+        }
         header.format = array;
         header.symmetry = general;
 

--- a/include/fast_matrix_market/app/doublet.hpp
+++ b/include/fast_matrix_market/app/doublet.hpp
@@ -89,7 +89,7 @@ namespace fast_matrix_market {
         header.object = vector;
         if (header.nnz > 0 && (values.cbegin() == values.cend())) {
             header.field = pattern;
-        } else if (header.field != pattern) {
+        } else if (header.field != pattern && options.fill_header_field_type) {
             header.field = get_field_type((const VT *) nullptr);
         }
         header.format = coordinate;

--- a/include/fast_matrix_market/app/generator.hpp
+++ b/include/fast_matrix_market/app/generator.hpp
@@ -86,7 +86,7 @@ namespace fast_matrix_market {
         header.nnz = nnz;
 
         header.object = matrix;
-        if (header.field != pattern) {
+        if (header.field != pattern && options.fill_header_field_type) {
             header.field = get_field_type((const VT *) nullptr);
         }
         header.format = coordinate;

--- a/include/fast_matrix_market/app/triplet.hpp
+++ b/include/fast_matrix_market/app/triplet.hpp
@@ -88,7 +88,7 @@ namespace fast_matrix_market {
         header.object = matrix;
         if (header.nnz > 0 && (values.cbegin() == values.cend())) {
             header.field = pattern;
-        } else if (header.field != pattern) {
+        } else if (header.field != pattern && options.fill_header_field_type) {
             header.field = get_field_type((const VT *) nullptr);
         }
         header.format = coordinate;
@@ -122,7 +122,7 @@ namespace fast_matrix_market {
         header.object = matrix;
         if (header.nnz > 0 && (values.cbegin() == values.cend())) {
             header.field = pattern;
-        } else if (header.field != pattern) {
+        } else if (header.field != pattern && options.fill_header_field_type) {
             header.field = get_field_type((const VT *) nullptr);
         }
         header.format = coordinate;

--- a/include/fast_matrix_market/app/user_type_string.hpp
+++ b/include/fast_matrix_market/app/user_type_string.hpp
@@ -1,0 +1,86 @@
+// Copyright (C) 2022-2023 Adam Lugowski. All rights reserved.
+// Use of this source code is governed by the BSD 2-clause license found in the LICENSE.txt file.
+// SPDX-License-Identifier: BSD-2-Clause
+
+/*
+ * Support std::string as a value type.
+ *
+ * Supports such things as a triplet where the value type is std::vector<std::string>, and such structure can read
+ * any Matrix Market file regardless of field type.
+ *
+ * IMPORTANT!
+ *
+ * If using this as a template for your own user type, note the weird #include ordering requirements!
+ *
+ * ```
+ * #include <fast_matrix_market/types.hpp>
+ *
+ * namespace fast_matrix_market {
+ *   // declare your type stuff here
+ * }
+ *
+ * // Now include the main header.
+ * #include <fast_matrix_market/fast_matrix_market.hpp>
+ * ```
+ */
+
+namespace fast_matrix_market {
+    /**
+     * (Needed for read) Parse a value.
+     *
+     * This method must find the end of the value, too. Likely the next newline or end of string is the end.
+     *
+     * @param pos starting character
+     * @param end end of string. Do not dereference >end.
+     * @param out out parameter of parsed value
+     * @return a pointer to the next character following the value. Likely the newline.
+     */
+    inline const char *read_value(const char *pos, const char *end, std::string &out, [[maybe_unused]] const read_options& options = {}) {
+        const char *field_start = pos;
+        // find the end of the line
+        while (pos != end && *pos != '\n') {
+            ++pos;
+        }
+        out = std::string(field_start, (pos - field_start));
+
+        return pos;
+    }
+
+    /**
+     * (Optional, used for read) Declare that read_value(std::string) declared above can read complex values too.
+     */
+    template<> struct can_read_complex<std::string> : std::true_type {};
+
+    /**
+     * (Needed for read) Used to handle skew-symmetric files. Must be defined regardless.
+     */
+    inline std::string negate(const std::string& o) {
+        return "-" + o;
+    }
+
+    /**
+     * (Needed for read) Default value to set for patterns (if option selected). Must be defined regardless.
+     */
+    inline std::string pattern_default_value([[maybe_unused]] const std::string* type) {
+        return "";
+    }
+
+    // If using default dense array loader, type must also work with std::plus<>.
+
+    /**
+     * (Needed for write) Used to determine what field type to set in the MatrixMarket header.
+     *
+     * IMPORTANT! This is the default type. If it does not match your actual data, set the appropriate type
+     * in the header, then use write_options::fill_header_field_type = false.
+     */
+    inline field_type get_field_type([[maybe_unused]] const std::string* type) {
+        return real;
+    }
+
+    /**
+     * (Needed for write) Write a value.
+     */
+    inline std::string value_to_string(const std::string& value, [[maybe_unused]] int precision) {
+        return value;
+    }
+}

--- a/include/fast_matrix_market/fast_matrix_market.hpp
+++ b/include/fast_matrix_market/fast_matrix_market.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <algorithm>
-#include <complex>
 #include <future>
 #include <iostream>
 #include <map>
@@ -17,6 +16,9 @@
 #include <utility>
 
 #include "types.hpp"
+
+// Support std::string as a user type
+#include "app/user_type_string.hpp"
 
 namespace fast_matrix_market {
 
@@ -28,9 +30,6 @@ namespace fast_matrix_market {
 
     constexpr std::string_view kSpace = " ";
     constexpr std::string_view kNewline = "\n";
-
-    template<class T> struct is_complex : std::false_type {};
-    template<class T> struct is_complex<std::complex<T>> : std::true_type {};
 
     /**
      *

--- a/include/fast_matrix_market/read_body.hpp
+++ b/include/fast_matrix_market/read_body.hpp
@@ -546,7 +546,7 @@ namespace fast_matrix_market {
                                  HANDLER& handler,
                                  typename HANDLER::value_type pattern_value,
                                  const read_options& options = {}) {
-        if (header.field == complex && !is_complex<typename HANDLER::value_type>::value) {
+        if (header.field == complex && !can_read_complex<typename HANDLER::value_type>::value) {
             // the file is complex but the values are not
             throw complex_incompatible("Matrix Market file has complex fields but passed data structure cannot handle complex values.");
         }

--- a/include/fast_matrix_market/types.hpp
+++ b/include/fast_matrix_market/types.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <complex>
 #include <map>
 #include <string>
 
@@ -143,5 +144,22 @@ namespace fast_matrix_market {
          * Whether to always write a comment line even if comment is empty.
          */
         bool always_comment = false;
+
+        /**
+         * Whether to determine header field type based on the supplied datastructure.
+         *
+         * If true then set header.field using `get_field_type()`. The only exception is
+         * if field == pattern then it is left unchanged.
+         *
+         * Possible reasons to set to false:
+         *  - Using a custom type, such as std::string, where `get_field_type()` would return the wrong type
+         *  - Writing integer structures as real
+         */
+        bool fill_header_field_type = true;
     };
+
+    template<class T> struct is_complex : std::false_type {};
+    template<class T> struct is_complex<std::complex<T>> : std::true_type {};
+
+    template<class T> struct can_read_complex : is_complex<T> {};
 }

--- a/tests/matrices/eye3_array.mtx
+++ b/tests/matrices/eye3_array.mtx
@@ -1,5 +1,4 @@
 %%MatrixMarket matrix array real general
-%
 3 3
 1
 0

--- a/tests/matrices/eye3_complex.mtx
+++ b/tests/matrices/eye3_complex.mtx
@@ -1,5 +1,4 @@
 %%MatrixMarket matrix coordinate complex general
-%
 3 3 3
 1 1 1 0
 2 2 1 0

--- a/tests/user_type_test.cpp
+++ b/tests/user_type_test.cpp
@@ -4,70 +4,13 @@
 
 #include <fstream>
 
-// Need some types from fast_matrix_market but cannot include the main header yet.
-// Include just the types so they can be used.
-#include <fast_matrix_market/types.hpp>
-
-// Test arbitrary types as the value type of the matrix.
-// Use T=std::string.
-//
-// Must declare read, write, and manipulation methods.
-// These must be declared before they're used, so before #include <fast_matrix_market/fast_matrix_market.hpp>
-namespace fast_matrix_market {
-    /**
-     * (Needed for read) Parse a value.
-     *
-     * This method must find the end of the value, too. Likely the next newline or end of string is the end.
-     *
-     * @param pos starting character
-     * @param end end of string. Do not dereference >end.
-     * @param out out parameter of parsed value
-     * @return a pointer to the next character following the value. Likely the newline.
-     */
-    const char *read_value(const char *pos, const char *end, std::string &out, [[maybe_unused]] const read_options& options = {}) {
-        while (pos != end && *pos != '\n') {
-            out += *pos;
-            ++pos;
-        }
-        return pos;
-    }
-
-    /**
-     * (Needed for read) Used to handle skew-symmetric files. Must be defined regardless.
-     */
-    std::string negate(const std::string& o) {
-        return "-" + o;
-    }
-
-    /**
-     * (Needed for read) Default value to set for patterns (if option selected). Must be defined regardless.
-     */
-    std::string pattern_default_value([[maybe_unused]] const std::string* type) {
-        return "1";
-    }
-
-    // If using default dense array loader, type must also work with std::plus<>.
-
-    /**
-     * (Needed for write) Used to determine what field type to set in the MatrixMarket header.
-     */
-    field_type get_field_type([[maybe_unused]] const std::string* type) {
-        return real;
-    }
-
-    /**
-     * (Needed for write) Write a value.
-     */
-    std::string value_to_string(const std::string& value, [[maybe_unused]] int precision) {
-        return value;
-    }
-}
-
-// Now we can include the main header.
 #include <fast_matrix_market/fast_matrix_market.hpp>
 
 #include "fmm_tests.hpp"
 
+// app/user_type_string.hpp defines the std::string user type.
+// It is now bundled with the main header for ease of use.
+// To define your own user type, define the methods defined in that header and read the note at the top of the file.
 
 using StrMat = triplet_matrix<int64_t, std::string>;
 
@@ -85,12 +28,15 @@ std::string read_file(const std::string& matrix_filename) {
  * Read MatrixMarket to a triplet.
  * @param mm string that contains the contents of a MatrixMarket file
  */
-StrMat read_triplet(const std::string& mm) {
+std::pair<StrMat, fast_matrix_market::matrix_market_header> read_triplet(const std::string& mm) {
     std::istringstream f(mm);
 
     StrMat triplet;
-    fast_matrix_market::read_matrix_market_triplet(f, triplet.nrows, triplet.ncols, triplet.rows, triplet.cols, triplet.vals);
-    return triplet;
+    fast_matrix_market::matrix_market_header header;
+    fast_matrix_market::read_matrix_market_triplet(f, header, triplet.rows, triplet.cols, triplet.vals);
+    triplet.nrows = header.nrows;
+    triplet.ncols = header.ncols;
+    return std::make_pair(triplet, header);
 }
 
 /**
@@ -99,21 +45,63 @@ StrMat read_triplet(const std::string& mm) {
  * @param triplet matrix to write
  * @return string contents of MatrixMarket file
  */
-std::string write_triplet(const StrMat& triplet) {
+std::string write_triplet(const StrMat& triplet, const fast_matrix_market::matrix_market_header& header) {
+    fast_matrix_market::write_options options;
+    options.fill_header_field_type = false;
     std::ostringstream f;
-    fast_matrix_market::write_matrix_market_triplet(f, {triplet.nrows, triplet.ncols}, triplet.rows, triplet.cols, triplet.vals);
+    fast_matrix_market::write_matrix_market_triplet(f, header, triplet.rows, triplet.cols, triplet.vals, options);
     return f.str();
 }
 
+
 TEST(UserTypeTest, String) {
-    StrMat m = read_triplet(read_file("eye3_str.mtx"));
-    EXPECT_EQ(m.vals.size(), 3);
+    {
+        std::string orig = read_file("eye3_str.mtx");
+        auto [m, header] = read_triplet(orig);
+        EXPECT_EQ(m.vals.size(), 3);
 
-    EXPECT_EQ(m.vals[0], "1");
-    EXPECT_EQ(m.vals[1], "1.0");
-    EXPECT_EQ(m.vals[2], "1E0");
+        EXPECT_EQ(m.vals[0], "1");
+        EXPECT_EQ(m.vals[1], "1.0");
+        EXPECT_EQ(m.vals[2], "1E0");
 
-    // Test writing.
-    std::string out = write_triplet(m);
-    EXPECT_EQ(m, read_triplet(out));
+        // Test writing.
+        std::string out = write_triplet(m, header);
+        EXPECT_EQ(orig, out);
+    }
+    {
+        std::string orig = read_file("eye3_pattern.mtx");
+        auto [m, header] = read_triplet(orig);
+        EXPECT_EQ(m.vals.size(), 3);
+
+        EXPECT_EQ(m.vals[0], "");
+        EXPECT_EQ(m.vals[1], "");
+        EXPECT_EQ(m.vals[2], "");
+
+        // Test writing.
+        std::string out = write_triplet(m, header);
+        EXPECT_EQ(orig, out);
+    }
+    {
+        std::string orig = read_file("eye3_complex.mtx");
+        auto [m, header] = read_triplet(orig);
+        EXPECT_EQ(m.vals.size(), 3);
+
+        EXPECT_EQ(m.vals[0], "1 0");
+        EXPECT_EQ(m.vals[1], "1 0");
+        EXPECT_EQ(m.vals[2], "1 0");
+
+        // Test writing.
+        std::string out = write_triplet(m, header);
+        EXPECT_EQ(orig, out);
+    }
+    {
+        std::string orig = read_file("vector_array.mtx");
+        auto [m, header] = read_triplet(orig);
+        EXPECT_EQ(m.vals.size(), 4);
+
+        EXPECT_EQ(m.vals[0], "101");
+        EXPECT_EQ(m.vals[1], "202");
+        EXPECT_EQ(m.vals[2], "0");
+        EXPECT_EQ(m.vals[3], "404");
+    }
 }


### PR DESCRIPTION
Enables, for example, using `std::vector<std::string>` for values.