### PR TITLE
Enable GraphBLAS binding to write arrays directly

### DIFF
--- a/tests/graphblas_test.cpp
+++ b/tests/graphblas_test.cpp
@@ -448,16 +448,20 @@ INSTANTIATE_TEST_SUITE_P(
         GraphBLASMatrixTest,
         GraphBLASMatrixTest,
         ::testing::Values("eye3.mtx"
-                , "row_3by4.mtx"
-                , "2col_array.mtx"
-                , "kepner_gilbert_graph.mtx"
-                , "vector_array.mtx"
-                , "vector_coordinate.mtx"
-                , "vector_coordinate_dupes.mtx"
-                , "eye3_pattern.mtx"
-                , "eye3_complex.mtx"
-                , "vector_coordinate_complex.mtx"
-                , "vector_coordinate_complex_dupes.mtx"
+            , "row_3by4.mtx"
+            , "2col_array.mtx"
+            , "kepner_gilbert_graph.mtx"
+            , "vector_array.mtx"
+            , "vector_coordinate.mtx"
+            , "vector_coordinate_dupes.mtx"
+            , "eye3_pattern.mtx"
+            , "eye3_complex.mtx"
+            , "vector_coordinate_complex.mtx"
+            , "vector_coordinate_complex_dupes.mtx"
+            , "symmetry_array/array_skew-symmetric.mtx"
+            , "symmetry_array/array_skew-symmetric_general.mtx"
+            , "symmetry_array/array_symmetric.mtx"
+            , "symmetry_array/array_symmetric_general.mtx"
         ));
 
 // Test %%GraphBLAS type <ctype>


### PR DESCRIPTION
Previous implementation would always write a coordinate file due to GraphBLAS iterators sometimes throwing GrB_NOT_IMPLEMENTED. Turns out that only throws when the matrix is GxB_BY_ROW, as Matrix Market requires column-major order and GraphBLAS appears to only support iterating on the native direction.

Note that this change is only efficient if the matrix is GxB_BY_COL as that is the only case where an iterator can be used. If the matrix is GxB_BY_ROW, then a full copy and sort is necessary, a very inefficient operation, but still better than writing a coordinate version of that matrix.