### PR TITLE
Register with threadpoolctl

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -101,7 +101,18 @@ header(shape=(3, 3), nnz=3, comment="3-by-3 identity matrix", object="matrix", f
 {'shape': (3, 3), 'nnz': 3, 'comment': '3-by-3 identity matrix', 'object': 'matrix', 'format': 'coordinate', 'field': 'real', 'symmetry': 'general'}
 ```
 
-**Note:** SciPy is only a runtime dependency for the `mmread` and `mmwrite` methods. All others depend only on NumPy.
+#### Controlling parallelism
+
+All methods other than `read_header` and `mminfo` accept a `parallelism` parameter that controls the number of threads used. Default is to use the same number of threads as cores on the system.
+```python
+mat = fmm.mmread("matrix.mtx", parallelism=2)  # will use 2 threads
+```
+
+Alternatively, use [threadpoolctl](https://pypi.org/project/threadpoolctl/):
+```python
+with threadpoolctl.threadpool_limits(limits=2, user_api='fast_matrix_market'):
+    mat = fmm.mmread("matrix.mtx")  # will use 2 threads
+```
 
 # Quick way to try
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -34,7 +34,7 @@ homepage = "https://github.com/alugowski/fast_matrix_market"
 repository = "https://github.com/alugowski/fast_matrix_market"
 
 [project.optional-dependencies]
-test = ["pytest", "scipy", "threadpoolctl>=3.2.0"]
+test = ["pytest", "scipy", "threadpoolctl"]
 
 [tool.scikit-build]
 wheel.expand-macos-universal-tags = true

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -34,7 +34,7 @@ homepage = "https://github.com/alugowski/fast_matrix_market"
 repository = "https://github.com/alugowski/fast_matrix_market"
 
 [project.optional-dependencies]
-test = ["pytest", "scipy", "threadpoolctl"]
+test = ["pytest", "scipy", "threadpoolctl>=3.2.0"]
 
 [tool.scikit-build]
 wheel.expand-macos-universal-tags = true

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -34,7 +34,7 @@ homepage = "https://github.com/alugowski/fast_matrix_market"
 repository = "https://github.com/alugowski/fast_matrix_market"
 
 [project.optional-dependencies]
-test = ["pytest", "scipy"]
+test = ["pytest", "scipy", "threadpoolctl"]
 
 [tool.scikit-build]
 wheel.expand-macos-universal-tags = true

--- a/python/src/fast_matrix_market/__init__.py
+++ b/python/src/fast_matrix_market/__init__.py
@@ -74,11 +74,8 @@ try:
             pass
 
     threadpoolctl.register(FMMThreadPoolCtlController)
-except ImportError:
-    # threadpoolctl not installed
-    pass
-except AttributeError as e:
-    # older version of threadpoolctl
+except (ImportError, AttributeError):
+    # threadpoolctl not installed, or an older version
     pass
 
 

--- a/python/src/fast_matrix_market/__init__.py
+++ b/python/src/fast_matrix_market/__init__.py
@@ -45,6 +45,42 @@ _field_to_dtype = {
     "long-pattern": "longdouble",
 }
 
+# Optional: Register with threadpoolctl
+try:
+    # noinspection PyUnresolvedReferences
+    import threadpoolctl
+
+    class FMMThreadPoolCtlController(threadpoolctl.LibController):
+        user_api = "fast_matrix_market"
+        internal_api = "fast_matrix_market"
+
+        filename_prefixes = ("_fmm_core",)
+
+        # noinspection PyMethodMayBeStatic
+        def get_num_threads(self):
+            global PARALLELISM
+            return PARALLELISM
+
+        # noinspection PyMethodMayBeStatic
+        def set_num_threads(self, num_threads):
+            global PARALLELISM
+            PARALLELISM = num_threads
+
+        # noinspection PyMethodMayBeStatic
+        def get_version(self):
+            return __version__
+
+        def set_additional_attributes(self):
+            pass
+
+    threadpoolctl.register(FMMThreadPoolCtlController)
+except ImportError:
+    # threadpoolctl not installed
+    pass
+except AttributeError as e:
+    # older version of threadpoolctl
+    pass
+
 
 class _TextToBytesWrapper(io.BufferedReader):
     """

--- a/python/tests/test_basic.py
+++ b/python/tests/test_basic.py
@@ -3,7 +3,13 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import unittest
+
 import fast_matrix_market as fmm
+
+try:
+    import threadpoolctl
+except ImportError:
+    threadpoolctl = None
 
 
 class TestModule(unittest.TestCase):
@@ -12,6 +18,12 @@ class TestModule(unittest.TestCase):
 
     def test_doc(self):
         self.assertTrue(fmm.__doc__)
+
+    @unittest.skipIf(not threadpoolctl or not hasattr(threadpoolctl, "register"),
+                     reason="no threadpoolctl or version too old")
+    def test_threadpoolctl(self):
+        with threadpoolctl.threadpool_limits(limits=2, user_api='fast_matrix_market'):
+            self.assertEqual(fmm.PARALLELISM, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Optional feature.

Currently requires a pre-release version of threadpoolctl, so do not merge until the `threadpoolctl` API is final.

closes https://github.com/alugowski/fast_matrix_market/issues/28