### PR TITLE
Python 3.12 and Linux aarch64 wheels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,12 +90,12 @@ jobs:
 
       - name: Install NumPy
         continue-on-error: true
-        # --only-binary disables compiling the package from source if a binary wheel is not available
+        # --only-binary disables compiling the package from source if a binary wheel is not available, such as some versions of PyPy
         run: pip install --only-binary ":all:" numpy
 
       - name: Install SciPy
         continue-on-error: true
-        # --only-binary disables compiling the package from source if a binary wheel is not available, such as scipy on PyPy
+        # --only-binary disables compiling the package from source if a binary wheel is not available, such as PyPy
         run: pip install --only-binary ":all:" scipy
 
       - name: Python Test

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,11 +2,6 @@ name: wheels
 
 on:
   workflow_dispatch:
-# Note: if enabling this more broadly ensure upload_all run permissions make sense.
-#  pull_request:
-#  push:
-#    branches:
-#      - main
   release:
     types:
       - published
@@ -49,54 +44,48 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Loosely based on scikit-learn's config:
+        # Originally based on scikit-learn's config:
         # https://github.com/scikit-learn/scikit-learn/blob/main/.github/workflows/wheels.yml
         include:
           - os: windows-latest
-            python-version: "3.7"
             platform_id: win_amd64
+
           - os: ubuntu-latest
-            python-version: "3.7"
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
           - os: ubuntu-latest
-            python-version: "3.7"
             platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
+
           - os: macos-latest
-            python-version: "3.7"
             platform_id: macosx_x86_64
-            # Switch to cross-compiling macOS ARM wheels on the Intel runner instead.
-#          - os: macos-latest
-#            python-version: "3.8"      # macOS ARM support starts with Python 3.8
-#            platform_id: macosx_arm64
+          - os: macos-latest
+            platform_id: macosx_arm64
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: pypa/cibuildwheel@v2.15.0
         with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Build Wheels
+          package-dir: python
+          output-dir: wheelhouse
         env:
+
           CIBW_BUILD_VERBOSITY: 3
-#          CIBW_BUILD: "cp*"
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+
           # No 32-bit builds. See https://cibuildwheel.readthedocs.io/en/stable/options/#archs
           # Note: if trying 32-bit builds, add CIBW_BEFORE_TEST: "pip install --only-binary :all: numpy scipy"
           CIBW_SKIP: "*-win32 *_i686"
+
+          # Allow pre-release numpy to test on newest Python
+          CIBW_BEFORE_TEST: pip install --pre numpy
+
           # make cibuildwheel install test dependencies from pyproject.toml
           CIBW_TEST_EXTRAS: "test"
+
           # run tests in the {package}/tests dir which is python/tests
           CIBW_TEST_COMMAND: "pytest {package}/tests"
-          # Skip testing on PyPy and musllinux because SciPy fails to install there.
-          # Also skip macOS ARM tests on Intel runner.
-          CIBW_TEST_SKIP: "pp* *musllinux* *-macosx_arm64"
-        run: |
-          python -m pip install cibuildwheel
-          python -m cibuildwheel --output-dir wheelhouse python
-        shell: bash
+
+          # Skip testing on PyPy and musllinux versions that SciPy does not ship wheels for.
+          CIBW_TEST_SKIP: "pp* cp37*musllinux* cp38*musllinux*"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -39,29 +39,38 @@ jobs:
 
 
   build_wheels:
-    name: Wheels on ${{ matrix.platform_id }} - ${{ matrix.os }}
+    name: Wheels on ${{ matrix.os }} - ${{ matrix.cibw_archs }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        # Originally based on scikit-learn's config:
+        # Originally based on scikit-learn's config, but has diverged since:
         # https://github.com/scikit-learn/scikit-learn/blob/main/.github/workflows/wheels.yml
         include:
           - os: windows-latest
-            platform_id: win_amd64
+            cibw_archs: "AMD64"
 
           - os: ubuntu-latest
-            platform_id: manylinux_x86_64
+            cibw_archs: "x86_64"
           - os: ubuntu-latest
-            platform_id: manylinux_aarch64
+            cibw_archs: "aarch64"
+            # numpy wheels not available for aarch64 PyPy or musllinux
+            cibw_skip: "pp* *musl*"
 
           - os: macos-latest
-            platform_id: macosx_x86_64
+            cibw_archs: "x86_64"
           - os: macos-latest
-            platform_id: macosx_arm64
+            cibw_archs: "arm64"
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup QEMU
+        # for building non-x86 Linux wheels on x86 runner
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
 
       - uses: pypa/cibuildwheel@v2.15.0
         with:
@@ -71,21 +80,24 @@ jobs:
 
           CIBW_BUILD_VERBOSITY: 3
 
-          # No 32-bit builds. See https://cibuildwheel.readthedocs.io/en/stable/options/#archs
-          # Note: if trying 32-bit builds, add CIBW_BEFORE_TEST: "pip install --only-binary :all: numpy scipy"
-          CIBW_SKIP: "*-win32 *_i686"
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
-          # Allow pre-release numpy to test on newest Python
-          CIBW_BEFORE_TEST: pip install --pre numpy
+          CIBW_SKIP: ${{ matrix.cibw_skip }}
+
+          # Allow pre-release to test on newest Python that may only have beta or RC numpy packages available.
+          # --only-binary and ' || true' to best-effort numpy and scipy installation.
+          # Some platforms do not have binary wheels for either package, some only for numpy.
+          # Notably PyPy: no scipy wheels, and numpy wheels for only some versions.
+          CIBW_BEFORE_TEST: pip install --pre --only-binary ":all:" numpy && pip install --pre --only-binary ":all:" scipy || true
 
           # make cibuildwheel install test dependencies from pyproject.toml
-          CIBW_TEST_EXTRAS: "test"
+          CIBW_TEST_EXTRAS: "testmin"
 
           # run tests in the {package}/tests dir which is python/tests
           CIBW_TEST_COMMAND: "pytest {package}/tests"
 
-          # Skip testing on PyPy and musllinux versions that SciPy does not ship wheels for.
-          CIBW_TEST_SKIP: "pp* cp37*musllinux* cp38*musllinux*"
+          # Skip macOS ARM tests on Intel runner.
+          CIBW_TEST_SKIP: "*-macosx_arm64"
 
       - uses: actions/upload-artifact@v3
         with:
@@ -111,10 +123,10 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           # PyPI does not allow replacing a file. Without this flag the entire action fails if even a single duplicate exists.
-          skip_existing: true
+          skip-existing: true
           verbose: true
           # Real PyPI:
           password: ${{ secrets.PYPI_API_TOKEN }}
           # Test PyPI:
 #          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-#          repository_url: https://test.pypi.org/legacy/
+#          repository-url: https://test.pypi.org/legacy/

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries",
     "Topic :: Scientific/Engineering",
 ]

--- a/python/tests/test_basic.py
+++ b/python/tests/test_basic.py
@@ -22,6 +22,14 @@ class TestModule(unittest.TestCase):
     @unittest.skipIf(not threadpoolctl or not hasattr(threadpoolctl, "register"),
                      reason="no threadpoolctl or version too old")
     def test_threadpoolctl(self):
+        import os
+        import sys
+        import pytest
+        if sys.platform == "darwin" and sys.version_info.minor == 8 and os.environ.get("CIBUILDWHEEL", 0):
+            pytest.xfail("threadpoolctl fails inside cibuildwheel macOS Python 3.8")
+            # see https://github.com/joblib/threadpoolctl/issues/150
+            return
+
         with threadpoolctl.threadpool_limits(limits=2, user_api='fast_matrix_market'):
             self.assertEqual(fmm.PARALLELISM, 2)
         with threadpoolctl.threadpool_limits(limits=4):


### PR DESCRIPTION
Note: Needs numpy 1.26 for py312 wheel tests to succeed. That is the earliest version to support Python 3.12, and as of writing is in RC.

See: https://github.com/numpy/numpy/releases
and: https://pypi.org/project/numpy/#history