### PR TITLE
Support C++23 fixed-width floating point types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,15 +6,27 @@ on:
 
 jobs:
   cpptests:
-    name: C++ Tests on ${{ matrix.os }}
+    name: C++ Tests on ${{ matrix.os }} ${{ matrix.description }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: windows-latest
+          - os: ubuntu-latest
+          - os: ubuntu-latest
+            gccver: "13"
+            description: "GCC 13"
+          - os: macos-latest
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Set up GCC
+      uses: egor-tensin/setup-gcc@v1
+      if: ${{ matrix.gccver != '' }}
+      with:
+        version: ${{ matrix.gccver }}
 
     - name: Install Integrations (Ubuntu)
       if: contains(matrix.os, 'ubuntu')
@@ -39,7 +51,6 @@ jobs:
       run: brew install suite-sparse
 
     - name: Configure
-      if: ${{ !contains(matrix.python-version, 'pypy') }}
       run: |
         cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DFAST_MATRIX_MARKET_TEST=ON -DFAST_MATRIX_MARKET_TEST_COVERAGE=ON ${{ env.FMM_CMAKE_FLAGS }}
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Then simply run all the cells in the [benchmark_plots/plot.ipynb](benchmark_plot
   * Support all C++ types.
     * `float`, `double`, `long double`, `std::complex<>`, integer types, `bool`.
     * Arbitrary types. `std::string` comes bundled. See [implementation](include/fast_matrix_market/app/user_type_string.hpp), [example usage](tests/user_type_test.cpp)
+    * C++23 fixed width floating point types like `std::float32_t`.
 
   * Automatic `std::complex` up-cast. For example, `real` files can be read into `std::complex<double>` arrays.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,14 +28,19 @@ set(MATRIX_DIR "${CMAKE_CURRENT_LIST_DIR}/matrices/")
 message("Test Matrix directory: ${MATRIX_DIR}")
 add_definitions(-DTEST_MATRIX_DIR="${MATRIX_DIR}")
 
+include(GoogleTest)
+
 add_executable(chunking_test chunking_test.cpp)
 target_link_libraries(chunking_test GTest::gtest_main fast_matrix_market::fast_matrix_market)
+gtest_discover_tests(chunking_test)
 
 add_executable(field_conv_test field_conv_test.cpp)
 target_link_libraries(field_conv_test GTest::gtest_main fast_matrix_market::fast_matrix_market)
+gtest_discover_tests(field_conv_test)
 
 add_executable(basic_test basic_test.cpp)
 target_link_libraries(basic_test GTest::gtest_main fast_matrix_market::fast_matrix_market)
+gtest_discover_tests(basic_test)
 
 add_executable(disabled_features_test disabled_features_test.cpp)
 target_link_libraries(disabled_features_test GTest::gtest_main fast_matrix_market::fast_matrix_market)
@@ -43,28 +48,35 @@ target_compile_definitions(disabled_features_test PUBLIC FMM_NO_VECTOR)
 
 add_executable(user_type_test user_type_test.cpp)
 target_link_libraries(user_type_test GTest::gtest_main fast_matrix_market::fast_matrix_market)
+gtest_discover_tests(user_type_test)
 
 add_executable(array_test array_test.cpp)
 target_link_libraries(array_test GTest::gtest_main fast_matrix_market::fast_matrix_market)
+gtest_discover_tests(array_test)
 
 add_executable(csc_test csc_test.cpp)
 target_link_libraries(csc_test GTest::gtest_main fast_matrix_market::fast_matrix_market)
+gtest_discover_tests(csc_test)
 
 add_executable(triplet_test triplet_test.cpp)
 target_link_libraries(triplet_test GTest::gtest_main fast_matrix_market::fast_matrix_market)
+gtest_discover_tests(triplet_test)
 
 add_executable(cxsparse_test cxsparse_test.cpp fake_cxsparse/cs.hpp)
 target_link_libraries(cxsparse_test GTest::gtest_main fast_matrix_market::fast_matrix_market)
-
-include(GoogleTest)
-gtest_discover_tests(chunking_test)
-gtest_discover_tests(field_conv_test)
-gtest_discover_tests(basic_test)
-gtest_discover_tests(user_type_test)
-gtest_discover_tests(array_test)
-gtest_discover_tests(triplet_test)
-gtest_discover_tests(csc_test)
 gtest_discover_tests(cxsparse_test)
+
+if ("cxx_std_23" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    include(stdfloat_tests.cmake)
+
+    if (have_stdfloat)
+        message("Including test for C++23 fixed-width floating point types")
+        add_executable(cpp23_test cpp23_test.cpp)
+        target_link_libraries(cpp23_test GTest::gtest_main fast_matrix_market::fast_matrix_market)
+        target_compile_features(cpp23_test PUBLIC cxx_std_23)
+        gtest_discover_tests(cpp23_test)
+    endif()
+endif()
 
 
 option(FAST_MATRIX_MARKET_TEST_EXTERNAL_APPS "Enable tests for bindings (e.g. Blaze, Eigen, etc.)" ON)

--- a/tests/cpp23_test.cpp
+++ b/tests/cpp23_test.cpp
@@ -1,0 +1,72 @@
+// Copyright (C) 2023 Adam Lugowski. All rights reserved.
+// Use of this source code is governed by the BSD 2-clause license found in the LICENSE.txt file.
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <algorithm>
+#include <fstream>
+#include <stdfloat>
+
+#include "fmm_tests.hpp"
+
+#if defined(__clang__)
+// for TYPED_TEST_SUITE
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#endif
+
+template <typename TRIPLET>
+void read_triplet_file(const std::string& matrix_filename, TRIPLET& triplet, fast_matrix_market::read_options options = {}) {
+    std::ifstream f(kTestMatrixDir + "/" + matrix_filename);
+    options.chunk_size_bytes = 1;
+
+    fast_matrix_market::read_matrix_market_triplet(f, triplet.nrows, triplet.ncols, triplet.rows, triplet.cols, triplet.vals, options);
+}
+
+template <typename TRIPLET>
+std::string write_triplet_string(TRIPLET& triplet, fast_matrix_market::write_options options = {}) {
+    std::ostringstream f;
+    options.chunk_size_values = 1;
+
+    fast_matrix_market::write_matrix_market_triplet(f, {triplet.nrows, triplet.ncols}, triplet.rows, triplet.cols, triplet.vals, options);
+    return f.str();
+}
+
+template <typename VT>
+std::string eye_cycle() {
+    triplet_matrix<int64_t, VT> eye3;
+    read_triplet_file("eye3.mtx", eye3);
+    return write_triplet_string(eye3);
+}
+
+TEST(Cpp23FixedWidthFloats, Eye) {
+    std::string expected = eye_cycle<double>();
+    std::string expected_complex = eye_cycle<std::complex<double>>();
+
+    // test pattern on floats
+    EXPECT_EQ(expected, eye_cycle<float>());
+    EXPECT_EQ(expected_complex, eye_cycle<std::complex<float>>());
+
+#if __STDCPP_FLOAT16_T__
+    EXPECT_EQ(expected, eye_cycle<std::float16_t>());
+    EXPECT_EQ(expected_complex, eye_cycle<std::complex<std::float16_t>>());
+#endif
+
+#if __STDCPP_FLOAT32_T__
+    EXPECT_EQ(expected, eye_cycle<std::float32_t>());
+    EXPECT_EQ(expected_complex, eye_cycle<std::complex<std::float32_t>>());
+#endif
+
+#if __STDCPP_FLOAT64_T__
+    EXPECT_EQ(expected, eye_cycle<std::float64_t>());
+    EXPECT_EQ(expected_complex, eye_cycle<std::complex<std::float64_t>>());
+#endif
+
+#if 0 && __STDCPP_FLOAT128_T__
+    // stdlib support for float128_t is incomplete. Missing <charconv> and stream overloads.
+    EXPECT_EQ(expected, eye_cycle<std::float128_t>());
+    EXPECT_EQ(expected_complex, eye_cycle<std::complex<std::float128_t>>());
+#endif
+
+#if __STDCPP_BFLOAT16_T__
+    EXPECT_EQ(expected, eye_cycle<std::bfloat16_t>());
+#endif
+}

--- a/tests/stdfloat_tests.cmake
+++ b/tests/stdfloat_tests.cmake
@@ -1,0 +1,17 @@
+# Test for C++23 fixed-width floating point support.
+include(CheckSourceCompiles)
+
+# CMP0067: Honor language standard in try_compile() source-file signature.
+# https://cmake.org/cmake/help/latest/policy/CMP0067.html
+cmake_policy(SET CMP0067 NEW)
+set(CMAKE_CXX_STANDARD 23)
+
+# Check for header
+check_source_compiles(CXX "
+#include <stdfloat>
+int main(void) {
+    return 0;
+}
+" have_stdfloat)
+
+set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
C++23 offers fixed-width floating point types `std::float16_t` through `std::float128_t` and `std::bfloat16_t`.

See https://en.cppreference.com/w/cpp/types/floating-point

This enables support for those types with the assumption that the `<charconv>` methods support the types. That is true for the only compiler with support for these types, GCC 13. The only exception is `std::float128_t`, which AFAIK has no string conversion methods in GCC 13's standard library.

Fixes #45 