### PR TITLE
Duplicate-free symmetric diagonals

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Install Integrations (Ubuntu)
       if: contains(matrix.os, 'ubuntu')
-      run: sudo apt-get install -y libarmadillo-dev
+      run: sudo apt-get update && sudo apt-get install -y libarmadillo-dev
 
     - name: Install GraphBLAS (ubuntu)
       if: contains(matrix.os, 'ubuntu')

--- a/include/fast_matrix_market/app/Blaze.hpp
+++ b/include/fast_matrix_market/app/Blaze.hpp
@@ -26,16 +26,16 @@ namespace fast_matrix_market {
         read_header(instream, header);
         mat.clear();
         mat.resize(header.nrows, header.ncols);
-        size_t storage_nnz = get_storage_nnz(header, options);
-        mat.reserve(storage_nnz);
 
         // Read into triplets
-        std::vector<IT> rows(storage_nnz);
-        std::vector<IT> cols(storage_nnz);
-        std::vector<VT> vals(storage_nnz);
+        std::vector<IT> rows;
+        std::vector<IT> cols;
+        std::vector<VT> vals;
 
-        auto handler = triplet_parse_handler(rows.begin(), cols.begin(), vals.begin());
-        read_matrix_market_body(instream, header, handler, default_pattern_value, options);
+        read_matrix_market_body_triplet(instream, header, rows, cols, vals, default_pattern_value, options);
+
+        size_t storage_nnz = vals.size();
+        mat.reserve(storage_nnz);
 
         // Set the values into the matrix from the triplets.
         // The matrix needs to be constructed row-by-row (if row-major) or column-by-column (if col-major), in order.

--- a/include/fast_matrix_market/app/CXSparse.hpp
+++ b/include/fast_matrix_market/app/CXSparse.hpp
@@ -14,10 +14,16 @@ namespace fast_matrix_market {
     void read_matrix_market_cxsparse(std::istream &instream,
                                     CS **cs,
                                     ALLOC spalloc,
-                                    const read_options& options = {}) {
+                                    read_options options = {}) {
 
         matrix_market_header header;
         read_header(instream, header);
+
+        // Sanitize symmetry generalization settings
+        if (options.generalize_symmetry && options.generalize_symmetry_app) {
+            // cs_compress drops zero elements
+            options.generalize_coordinate_diagnonal_values = read_options::ExtraZeroElement;
+        }
 
         // allocate
         *cs = spalloc(header.nrows, header.ncols, get_storage_nnz(header, options),

--- a/include/fast_matrix_market/app/Eigen.hpp
+++ b/include/fast_matrix_market/app/Eigen.hpp
@@ -23,7 +23,7 @@ namespace fast_matrix_market {
     void read_matrix_market_eigen(std::istream &instream,
                                   matrix_market_header &header,
                                   SparseType& mat,
-                                  const read_options& options = {},
+                                  read_options options = {},
                                   typename SparseType::Scalar default_pattern_value = 1) {
 
         typedef typename SparseType::Scalar Scalar;
@@ -32,6 +32,12 @@ namespace fast_matrix_market {
 
         read_header(instream, header);
         mat.resize(header.nrows, header.ncols);
+
+        // Sanitize symmetry generalization settings
+        if (options.generalize_symmetry && options.generalize_symmetry_app) {
+            // setFromTriplets() drops zero elements
+            options.generalize_coordinate_diagnonal_values = read_options::ExtraZeroElement;
+        }
 
         // read into tuples
         std::vector<Triplet> elements;

--- a/include/fast_matrix_market/app/GraphBLAS.hpp
+++ b/include/fast_matrix_market/app/GraphBLAS.hpp
@@ -550,12 +550,18 @@ namespace fast_matrix_market {
     void read_body_graphblas_coordinate(std::istream &instream,
                                         matrix_market_header &header,
                                         GrB_Matrix mat,
-                                        const read_options& options) {
+                                        read_options options) {
         size_t storage_nnz = get_storage_nnz(header, options);
 
         // Read into triplets
         std::vector<GrB_Index> rows(storage_nnz);
         std::vector<GrB_Index> cols(storage_nnz);
+
+        // Sanitize symmetry generalization settings
+        if (options.generalize_symmetry && options.generalize_symmetry_app) {
+            // Matrix construction drops zero elements
+            options.generalize_coordinate_diagnonal_values = read_options::ExtraZeroElement;
+        }
 
 #if FMM_GXB_BUILD_SCALAR
         if (header.field == pattern) {

--- a/include/fast_matrix_market/app/triplet.hpp
+++ b/include/fast_matrix_market/app/triplet.hpp
@@ -37,6 +37,75 @@ namespace fast_matrix_market {
 #endif
 
     /**
+     * Generalize symmetry of triplet.
+     *
+     * Does not duplicate diagonal elements.
+     */
+    template <typename IVEC, typename VVEC>
+    void generalize_symmetry_triplet(IVEC& rows, IVEC& cols, VVEC& values, const symmetry_type& symmetry) {
+        if (symmetry == general) {
+            return;
+        }
+
+        std::size_t num_diagonal_elements = 0;
+
+        // count how many diagonal elements there are (these do not get duplicated)
+        for (std::size_t i = 0; i < rows.size(); ++i) {
+            if (rows[i] == cols[i]) {
+                ++num_diagonal_elements;
+            }
+        }
+
+        // resize vectors
+        auto orig_size = rows.size();
+        auto new_size = 2*orig_size - num_diagonal_elements;
+        rows.resize(new_size);
+        cols.resize(new_size);
+        values.resize(new_size);
+
+        // fill in the new values
+        auto row_iter = rows.begin() + orig_size;
+        auto col_iter = cols.begin() + orig_size;
+        auto val_iter = values.begin() + orig_size;
+        for (std::size_t i = 0; i < orig_size; ++i) {
+            if (rows[i] == cols[i]) {
+                continue;
+            }
+
+            *row_iter = cols[i];
+            *col_iter = rows[i];
+            *val_iter = get_symmetric_value<typename VVEC::value_type>(values[i], symmetry);
+
+            ++row_iter; ++col_iter; ++val_iter;
+        }
+    }
+
+    template <triplet_read_vector IVEC, triplet_read_vector VVEC, typename T>
+    void read_matrix_market_body_triplet(std::istream &instream,
+                                         const matrix_market_header& header,
+                                         IVEC& rows, IVEC& cols, VVEC& values,
+                                         T pattern_value,
+                                         read_options options = {}) {
+        bool app_generalize = false;
+        if (options.generalize_symmetry && options.generalize_symmetry_app) {
+            app_generalize = true;
+            options.generalize_symmetry = false;
+        }
+
+        auto nnz = get_storage_nnz(header, options);
+        rows.resize(nnz);
+        cols.resize(nnz);
+        values.resize(nnz);
+
+        auto handler = triplet_parse_handler(rows.begin(), cols.begin(), values.begin());
+        read_matrix_market_body(instream, header, handler, pattern_value, options);
+
+        if (app_generalize) {
+            generalize_symmetry_triplet(rows, cols, values, header.symmetry);
+        }
+    }
+
+    /**
      * Read a Matrix Market file into a triplet (i.e. row, column, value vectors).
      */
     template <triplet_read_vector IVEC, triplet_read_vector VVEC>
@@ -44,16 +113,10 @@ namespace fast_matrix_market {
                                     matrix_market_header& header,
                                     IVEC& rows, IVEC& cols, VVEC& values,
                                     const read_options& options = {}) {
-        using VT = typename std::iterator_traits<decltype(values.begin())>::value_type;
-
         read_header(instream, header);
 
-        rows.resize(get_storage_nnz(header, options));
-        cols.resize(get_storage_nnz(header, options));
-        values.resize(get_storage_nnz(header, options));
-
-        auto handler = triplet_parse_handler(rows.begin(), cols.begin(), values.begin());
-        read_matrix_market_body(instream, header, handler, pattern_default_value((const VT*)nullptr), options);
+        using VT = typename std::iterator_traits<decltype(values.begin())>::value_type;
+        read_matrix_market_body_triplet(instream, header, rows, cols, values, pattern_default_value((const VT*)nullptr), options);
     }
 
     /**

--- a/include/fast_matrix_market/fast_matrix_market.hpp
+++ b/include/fast_matrix_market/fast_matrix_market.hpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <sstream>
 #include <utility>
+#include <vector>
 
 #include "types.hpp"
 
@@ -116,6 +117,10 @@ namespace fast_matrix_market {
      * MSVC does not like std::negate<bool>
      */
     inline bool negate(const bool o) {
+        return !o;
+    }
+
+    inline bool negate(const std::vector<bool>::reference o) {
         return !o;
     }
 

--- a/include/fast_matrix_market/read_body.hpp
+++ b/include/fast_matrix_market/read_body.hpp
@@ -104,6 +104,25 @@ namespace fast_matrix_market {
     // Chunks
     ///////////////////////////////////////////////////////////////////
 
+    template <typename RET, typename T>
+    RET get_symmetric_value(const T& v, const symmetry_type& symmetry) {
+        switch (symmetry) {
+            case symmetric:
+                return v;
+            case skew_symmetric:
+                if constexpr (std::is_unsigned_v<T>) {
+                    throw invalid_argument("Cannot load skew-symmetric matrix into unsigned value type.");
+                } else {
+                    return negate(v);
+                }
+            case hermitian:
+                return complex_conjugate(v);
+            case general:
+                return v;
+        }
+        return v;
+    }
+
     template<typename HANDLER, typename IT, typename VT>
     void generalize_symmetry_coordinate(HANDLER& handler,
                                         const matrix_market_header &header,
@@ -445,11 +464,9 @@ namespace fast_matrix_market {
         }
 #endif
 
-        // Verify generalize symmetry is compatible with this file.
-        if (header.symmetry != general && options.generalize_symmetry) {
-            if (header.object != matrix) {
-                throw invalid_mm("Invalid Symmetry: vectors cannot have symmetry. Set generalize_symmetry=false to disregard this symmetry.");
-            }
+        // Sanity check input
+        if (header.object == vector && header.symmetry != general) {
+            throw invalid_mm("Vectors cannot have symmetry.");
         }
 
         if (header.format == array && header.field == pattern) {

--- a/include/fast_matrix_market/types.hpp
+++ b/include/fast_matrix_market/types.hpp
@@ -89,6 +89,13 @@ namespace fast_matrix_market {
         bool generalize_symmetry = true;
 
         /**
+         * If true, perform symmetry generalization in the application binding as a post-processing step.
+         * If supported by the binding this method can avoid extra diagonal elements.
+         * If false or unsupported, diagonals are handled according to `generalize_coordinate_diagnonal_values`.
+         */
+        bool generalize_symmetry_app = true;
+
+        /**
          * Generalize Symmetry:
          * How to handle a value on the diagonal of a symmetric coordinate matrix.
          *  - DuplicateElement: Duplicate the diagonal element

--- a/tests/armadillo_test.cpp
+++ b/tests/armadillo_test.cpp
@@ -117,3 +117,18 @@ TYPED_TEST(ArmadilloTest, SmallMatrices) {
         }
     }
 }
+
+TEST(ArmadilloTest, Symmetric) {
+    arma::SpMat<double> sym, expected;
+
+    {
+        std::ifstream f(kTestMatrixDir + "symmetry/coordinate_symmetric_row.mtx");
+        fast_matrix_market::read_matrix_market_arma(f, sym);
+    }
+    {
+        std::ifstream f(kTestMatrixDir + "symmetry/coordinate_symmetric_row_general.mtx");
+        fast_matrix_market::read_matrix_market_arma(f, expected);
+    }
+    EXPECT_EQ(expected.n_nonzero, sym.n_nonzero);
+    EXPECT_TRUE(arma::approx_equal(expected, sym, "absdiff", 1e-6));
+}

--- a/tests/blaze_test.cpp
+++ b/tests/blaze_test.cpp
@@ -187,6 +187,22 @@ TYPED_TEST(BlazeMatrixTest, SmallMatrices) {
     }
 }
 
+
+TEST(BlazeMatrixTest, Symmetric) {
+    blaze::CompressedMatrix<double, blaze::rowMajor> sym, expected;
+
+    {
+        std::ifstream f(kTestMatrixDir + "symmetry/coordinate_symmetric_row.mtx");
+        fast_matrix_market::read_matrix_market_blaze(f, sym);
+    }
+    {
+        std::ifstream f(kTestMatrixDir + "symmetry/coordinate_symmetric_row_general.mtx");
+        fast_matrix_market::read_matrix_market_blaze(f, expected);
+    }
+    EXPECT_TRUE(is_equal(sym, expected));
+}
+
+
 /////////////////////////////////////////////////////////
 ///// Vectors
 /////////////////////////////////////////////////////////

--- a/tests/cxsparse_test.cpp
+++ b/tests/cxsparse_test.cpp
@@ -80,7 +80,7 @@ TEST_P(CSCTest, ReadSmall) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-        CSCTest,
+        CXSparse,
         CSCTest,
         ::testing::Values("eye3.mtx"
                           , "row_3by4.mtx"
@@ -89,3 +89,10 @@ INSTANTIATE_TEST_SUITE_P(
                           , "vector_coordinate.mtx"
                           , "eye3_pattern.mtx"
         ));
+
+TEST(CXSparse, Symmetric) {
+    cs_dl *sym = read_mtx(kTestMatrixDir + "symmetry/coordinate_symmetric_row.mtx");
+    cs_dl *expected = read_mtx(kTestMatrixDir + "symmetry/coordinate_symmetric_row_general.mtx");
+    EXPECT_EQ(6, sym->nzmax);
+    EXPECT_EQ(5, expected->nzmax);
+}

--- a/tests/eigen_test.cpp
+++ b/tests/eigen_test.cpp
@@ -151,3 +151,18 @@ INSTANTIATE_TEST_SUITE_P(
                           , Param{Param::Load_FMM_Vec, "vector_coordinate.mtx"}
                           , Param{Param::Load_FMM, "eye3_pattern.mtx"}
                           ));
+
+
+TEST(EigenTest, Symmetric) {
+    SpRowMajor sym, expected;
+
+    {
+        std::ifstream f(kTestMatrixDir + "symmetry/coordinate_symmetric_row.mtx");
+        fast_matrix_market::read_matrix_market_eigen(f, sym);
+    }
+    {
+        std::ifstream f(kTestMatrixDir + "symmetry/coordinate_symmetric_row_general.mtx");
+        fast_matrix_market::read_matrix_market_eigen(f, expected);
+    }
+    EXPECT_TRUE(expected.isApprox(sym, 1e-6));
+}

--- a/tests/graphblas_test.cpp
+++ b/tests/graphblas_test.cpp
@@ -534,6 +534,20 @@ TEST(GraphBLASMatrixTest, TypeComment) {
    }
 }
 
+TEST(GraphBLASMatrixTest, Symmetric) {
+    GrB_Matrix sym, expected;
+
+    {
+        std::ifstream f(kTestMatrixDir + "symmetry/coordinate_symmetric_row.mtx");
+        fast_matrix_market::read_matrix_market_graphblas(f, &sym);
+    }
+    {
+        std::ifstream f(kTestMatrixDir + "symmetry/coordinate_symmetric_row_general.mtx");
+        fast_matrix_market::read_matrix_market_graphblas(f, &expected);
+    }
+    EXPECT_TRUE(is_equal(expected, sym));
+}
+
 
 /////////////////////////////////////////////////////////
 ///// Vectors

--- a/tests/matrices/symmetry/coordinate_hermitian_real_row_general_zero.mtx
+++ b/tests/matrices/symmetry/coordinate_hermitian_real_row_general_zero.mtx
@@ -1,8 +1,9 @@
 %%MatrixMarket matrix coordinate real general
-% general version (diagonal element not duplicated)
-3 3 5
+% general version (diagonal element zero)
+3 3 6
 1 3 10
 3 1 10
 2 3 20
 3 2 20
+3 3 0
 3 3 30

--- a/tests/matrices/symmetry/coordinate_hermitian_row_general_zero.mtx
+++ b/tests/matrices/symmetry/coordinate_hermitian_row_general_zero.mtx
@@ -1,8 +1,9 @@
 %%MatrixMarket matrix coordinate complex general
-% general version (diagonal element not duplicated)
-3 3 5
+% general version (diagonal element zero)
+3 3 6
 1 3 10 -1
 3 1 10 1
 2 3 20 -2
 3 2 20 2
+3 3 0 -0
 3 3 30 0

--- a/tests/matrices/symmetry/coordinate_pattern_symmetric_row_general.mtx
+++ b/tests/matrices/symmetry/coordinate_pattern_symmetric_row_general.mtx
@@ -1,5 +1,5 @@
 %%MatrixMarket matrix coordinate pattern general
-% general version (diagonal element zero). Skew-symmetric matrices must have diagonal = 0
+% general version (diagonal element not duplicated). Skew-symmetric matrices must have diagonal = 0
 3 3 4
 1 3
 3 1

--- a/tests/matrices/symmetry/coordinate_pattern_symmetric_row_general_zero.mtx
+++ b/tests/matrices/symmetry/coordinate_pattern_symmetric_row_general_zero.mtx
@@ -1,0 +1,7 @@
+%%MatrixMarket matrix coordinate pattern general
+% general version (diagonal element zero). Skew-symmetric matrices must have diagonal = 0
+3 3 4
+1 3
+3 1
+2 3
+3 2

--- a/tests/matrices/symmetry/coordinate_skew_symmetric_row_general.mtx
+++ b/tests/matrices/symmetry/coordinate_skew_symmetric_row_general.mtx
@@ -1,5 +1,5 @@
 %%MatrixMarket matrix coordinate real general
-% general version (diagonal element zero). Skew-symmetric matrices must have diagonal = 0
+% general version (diagonal element not duplicated). Skew-symmetric matrices must have diagonal = 0
 3 3 4
 1 3 -10
 3 1 10

--- a/tests/matrices/symmetry/coordinate_skew_symmetric_row_general_zero.mtx
+++ b/tests/matrices/symmetry/coordinate_skew_symmetric_row_general_zero.mtx
@@ -1,0 +1,7 @@
+%%MatrixMarket matrix coordinate real general
+% general version (diagonal element zero). Skew-symmetric matrices must have diagonal = 0
+3 3 4
+1 3 -10
+3 1 10
+2 3 -20
+3 2 20

--- a/tests/matrices/symmetry/coordinate_symmetric_row_general.mtx
+++ b/tests/matrices/symmetry/coordinate_symmetric_row_general.mtx
@@ -1,9 +1,8 @@
 %%MatrixMarket matrix coordinate real general
-% general version (diagonal element zero)
-3 3 6
+% general version (diagonal element not duplicated)
+3 3 5
 1 3 10
 3 1 10
 2 3 20
 3 2 20
-3 3 0
 3 3 30

--- a/tests/matrices/symmetry/coordinate_symmetric_row_general_zero.mtx
+++ b/tests/matrices/symmetry/coordinate_symmetric_row_general_zero.mtx
@@ -1,8 +1,9 @@
 %%MatrixMarket matrix coordinate real general
-% general version (diagonal element not duplicated)
-3 3 5
+% general version (diagonal element zero)
+3 3 6
 1 3 10
 3 1 10
 2 3 20
 3 2 20
+3 3 0
 3 3 30


### PR DESCRIPTION
Add a read option to request symmetry generalization to be done by the application bindings.

For example, the triplet loader will load a `symmetric` matrix market file as is, then create the symmetric elements. This allows a scan to identify diagonal elements, and the final output does not have extra zero elements on the diagonals.

See https://github.com/alugowski/fast_matrix_market/issues/49