### PR TITLE
Support older CMake 3.14+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,8 @@ jobs:
         include:
           - os: windows-latest
           - os: ubuntu-latest
+            gccver: "9"
+            description: "GCC 9"
           - os: ubuntu-latest
             gccver: "13"
             description: "GCC 13"
@@ -22,11 +24,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up GCC
+    - name: Setup GCC
       uses: egor-tensin/setup-gcc@v1
       if: ${{ matrix.gccver != '' }}
       with:
         version: ${{ matrix.gccver }}
+
+    # build on minimum CMake version specified in CMakeLists.txt
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v1
+      if: contains(matrix.os, 'ubuntu')
+      with:
+        cmake-version: '3.14'
 
     - name: Install Integrations (Ubuntu)
       if: contains(matrix.os, 'ubuntu')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19...3.25) # needed for CheckSourceCompiles
+cmake_minimum_required(VERSION 3.14...3.26)
 
 # Read the version from fast_matrix_market.hpp
 set(VERSION_HEADER_FILE include/fast_matrix_market/fast_matrix_market.hpp)

--- a/cmake/GraphBLAS.cmake
+++ b/cmake/GraphBLAS.cmake
@@ -11,7 +11,7 @@ find_package(GraphBLAS QUIET MODULE)
 
 # See if GraphBLAS is installed system-wide already
 if (NOT GraphBLAS_FOUND)
-    check_source_compiles(CXX "
+    check_cxx_source_compiles("
     #include <GraphBLAS.h>
     int main(void) { return 0; }
     " GRAPHBLAS_H_AVAILABLE)

--- a/cmake/from_chars_tests.cmake
+++ b/cmake/from_chars_tests.cmake
@@ -1,6 +1,6 @@
 # Test for float version of std::from_chars.
 # The method is specified in C++17, but compiler support varies.
-include(CheckSourceCompiles)
+include(CheckCXXSourceCompiles)
 
 # CMP0067: Honor language standard in try_compile() source-file signature.
 # https://cmake.org/cmake/help/latest/policy/CMP0067.html
@@ -8,7 +8,7 @@ cmake_policy(SET CMP0067 NEW)
 set(CMAKE_CXX_STANDARD 17)
 
 # Check for int support
-check_source_compiles(CXX "
+check_cxx_source_compiles("
 #include <charconv>
 int main(void) {
     int value = 0;
@@ -19,7 +19,7 @@ int main(void) {
 " from_chars_int_supported)
 
 # Check for double support
-check_source_compiles(CXX "
+check_cxx_source_compiles("
 #include <charconv>
 int main(void) {
     double value = 0;
@@ -30,7 +30,7 @@ int main(void) {
 " from_chars_double_supported)
 
 # Check for long double support
-check_source_compiles(CXX "
+check_cxx_source_compiles("
 #include <charconv>
 int main(void) {
     long double value = 0;

--- a/cmake/to_chars_tests.cmake
+++ b/cmake/to_chars_tests.cmake
@@ -1,6 +1,6 @@
 # Test for std::to_chars.
 # The floating point versions are specified in C++17, but compiler support varies.
-include(CheckSourceCompiles)
+include(CheckCXXSourceCompiles)
 
 # CMP0067: Honor language standard in try_compile() source-file signature.
 # https://cmake.org/cmake/help/latest/policy/CMP0067.html
@@ -8,7 +8,7 @@ cmake_policy(SET CMP0067 NEW)
 set(CMAKE_CXX_STANDARD 17)
 
 # Check for int support
-check_source_compiles(CXX "
+check_cxx_source_compiles("
 #include <charconv>
 int main(void) {
     int value = 0;
@@ -19,7 +19,7 @@ int main(void) {
 " to_chars_int_supported)
 
 # Check for double support
-check_source_compiles(CXX "
+check_cxx_source_compiles("
 #include <charconv>
 int main(void) {
     double value = 0;
@@ -30,7 +30,7 @@ int main(void) {
 " to_chars_double_supported)
 
 # Check for long double support
-check_source_compiles(CXX "
+check_cxx_source_compiles("
 #include <charconv>
 int main(void) {
     long double value = 0;


### PR DESCRIPTION
Some distros (Debian) still sometimes have an older version of CMake, typically 3.18. 

This switches away from `check_source_compiles` (a CMake 3.19+ feature) to `check_cxx_source_compiles` to support older CMake and those older platforms.