### PR TITLE
Support older GCC/Clang that require extra link flags for C++11 threads

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,26 @@ jobs:
       matrix:
         include:
           - os: windows-latest
+
+          - os: ubuntu-20.04
+            llvm-version: "8"
+            description: "LLVM 8"
+
+          - os: ubuntu-20.04
+            gcc-version: "8"
+            description: "GCC 8"
+
           - os: ubuntu-latest
-            gccver: "9"
+            gcc-version: "9"
+            # test minimum CMake version specified in CMakeLists.txt
+            cmake-version: '3.14'
             description: "GCC 9"
+
           - os: ubuntu-latest
-            gccver: "13"
+            gcc-version: "13"
+            cmake-version: '3.14'
             description: "GCC 13"
+
           - os: macos-latest
 
     steps:
@@ -26,16 +40,22 @@ jobs:
 
     - name: Setup GCC
       uses: egor-tensin/setup-gcc@v1
-      if: ${{ matrix.gccver != '' }}
+      if: ${{ matrix.gcc-version != '' }}
       with:
-        version: ${{ matrix.gccver }}
+        version: ${{ matrix.gcc-version }}
 
-    # build on minimum CMake version specified in CMakeLists.txt
+    - name: Setup LLVM and Clang
+      uses: KyleMayes/install-llvm-action@v1
+      if: ${{ matrix.llvm-version != '' }}
+      with:
+        version: ${{ matrix.llvm-version }}
+        env: true
+
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v1
-      if: contains(matrix.os, 'ubuntu')
+      if: ${{ matrix.cmake-version != '' }}
       with:
-        cmake-version: '3.14'
+        cmake-version: ${{ matrix.cmake-version }}
 
     # test that the examples build
     - name: Build examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ target_include_directories(
 
 target_compile_features(fast_matrix_market INTERFACE cxx_std_17)
 
+# Some older compilers (eg. Clang, GCC <9) require extra link flags for C++11 threads
+find_package(Threads)
+target_link_libraries(fast_matrix_market INTERFACE Threads::Threads)
+
+# CMake options to enable/disable dependencies
 option(FMM_USE_FAST_FLOAT "Enable fast_float float/double parser" ON)
 option(FMM_USE_DRAGONBOX "Enable dragonbox float/double formatter for shortest representation" ON)
 option(FMM_USE_RYU "Enable Ryu float/double formatter with precision support" ON)

--- a/include/fast_matrix_market/parse_handlers.hpp
+++ b/include/fast_matrix_market/parse_handlers.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <algorithm>
-#include <charconv>
 #include <complex>
 #include <functional>
 #include <iterator>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,7 +40,10 @@ gtest_discover_tests(field_conv_test)
 
 add_executable(basic_test basic_test.cpp)
 target_link_libraries(basic_test GTest::gtest_main fast_matrix_market::fast_matrix_market)
-gtest_discover_tests(basic_test)
+if (NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9))
+    # GCC 8 has an interaction with GTest
+    gtest_discover_tests(basic_test)
+endif ()
 
 add_executable(disabled_features_test disabled_features_test.cpp)
 target_link_libraries(disabled_features_test GTest::gtest_main fast_matrix_market::fast_matrix_market)


### PR DESCRIPTION
Use `FindThreads` in CMakeLists.txt and add tests against old GCC and LLVM.

See #54 