### PR TITLE
Add cstdint include to types.h

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Setup MinGW (Windows)
       if: contains(matrix.os, 'windows') && matrix.mingw-version != ''
       run: |
-        choco install mingw --version ${{ matrix.mingw-version }}
+        choco install --no-progress mingw --version ${{ matrix.mingw-version }}
         Add-Content $env:GITHUB_PATH "C:\ProgramData\mingw64\mingw64\bin"
 
     - name: Setup LLVM and Clang

--- a/include/fast_matrix_market/types.hpp
+++ b/include/fast_matrix_market/types.hpp
@@ -6,6 +6,7 @@
 
 #include <complex>
 #include <map>
+#include <cstdint>
 #include <string>
 
 namespace fast_matrix_market {


### PR DESCRIPTION
Match fix from SciPy. https://github.com/scipy/scipy/pull/19588

There this missing include caused an issue on MinGW 13 from MSYS. That does not happen in CI here, neither on GCC 13 nor MinGW 13 (from choco). 