### PR TITLE
Prevent a possible clash with SciPy 1.12's FMM

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -148,11 +148,13 @@ jobs:
 
       - name: Install NumPy
         # --only-binary disables compiling the package from source if a binary wheel is not available, such as some versions of PyPy
-        run: pip install --only-binary ":all:" numpy || true
+        # `--pre` to test against RCs, if any
+        run: pip install --pre --only-binary ":all:" numpy || true
 
       - name: Install SciPy
         # --only-binary disables compiling the package from source if a binary wheel is not available, such as PyPy
-        run: pip install --only-binary ":all:" scipy || true
+        # `--pre` to test against RCs, if any
+        run: pip install --pre --only-binary ":all:" scipy || true
 
       - name: Python Test
         working-directory: python/tests

--- a/python/src/fast_matrix_market/_fmm_core.cpp
+++ b/python/src/fast_matrix_market/_fmm_core.cpp
@@ -195,7 +195,7 @@ PYBIND11_MODULE(_fmm_core, m) {
         }
     });
 
-    py::class_<fmm::matrix_market_header>(m, "header")
+    py::class_<fmm::matrix_market_header>(m, "header", py::module_local())
 #ifndef FMM_SCIPY_PRUNE
     .def(py::init<>())
     .def(py::init<int64_t, int64_t>())
@@ -224,7 +224,7 @@ PYBIND11_MODULE(_fmm_core, m) {
 #endif
     ///////////////////////////////
     // Read methods
-    py::class_<read_cursor>(m, "_read_cursor")
+    py::class_<read_cursor>(m, "_read_cursor", py::module_local())
     .def_readonly("header", &read_cursor::header)
     .def("close", &read_cursor::close);
 
@@ -236,7 +236,7 @@ PYBIND11_MODULE(_fmm_core, m) {
 
     ///////////////////////////////
     // Write methods
-    py::class_<write_cursor>(m, "_write_cursor")
+    py::class_<write_cursor>(m, "_write_cursor", py::module_local())
 #ifndef FMM_SCIPY_PRUNE
     .def_readwrite("header", &write_cursor::header)
 #endif

--- a/python/tests/test_scipy.py
+++ b/python/tests/test_scipy.py
@@ -132,6 +132,8 @@ class TestSciPy(unittest.TestCase):
 
                 self.assertMatrixEqual(m, m_fmm)
 
+    @unittest.skipIf(scipy is None or not scipy.__version__.startswith("1.11"),
+                     "SciPy 1.12 ships FMM so this no longer crashes.")
     def test_scipy_crashes(self):
         for mtx in sorted(list((matrices / "scipy_crashes").glob("*.mtx*"))):
             with self.subTest(msg=mtx.stem):


### PR DESCRIPTION
Make pybind11 classes py::module_local.

Fixes #62 