### PR TITLE
Fix typos

### DIFF
--- a/dependencies/fast_float/include/fast_float/fast_float.h
+++ b/dependencies/fast_float/include/fast_float/fast_float.h
@@ -893,7 +893,7 @@ constexpr uint64_t min_safe_u64(int base) { return int_luts<>::min_safe_u64[base
 namespace fast_float {
 /**
  * This function parses the character sequence [first,last) for a number. It parses floating-point numbers expecting
- * a locale-indepent format equivalent to what is used by std::strtod in the default ("C") locale.
+ * a locale-independent format equivalent to what is used by std::strtod in the default ("C") locale.
  * The resulting floating-point value is the closest floating-point values (using either float or double),
  * using the "round to even" convention for values that would otherwise fall right in-between two values.
  * That is, we provide exact parsing according to the IEEE standard.
@@ -3492,7 +3492,7 @@ fastfloat_really_inline bool rounds_to_nearest() noexcept {
   // However, it is expected to be much faster than the fegetround()
   // function call.
   //
-  // The volatile keywoard prevents the compiler from computing the function
+  // The volatile keyword prevents the compiler from computing the function
   // at compile-time.
   // There might be other ways to prevent compile-time optimizations (e.g., asm).
   // The value does not need to be std::numeric_limits<float>::min(), any small

--- a/examples/simple1.cpp
+++ b/examples/simple1.cpp
@@ -54,7 +54,7 @@ int main() {
         // construct an instance of fast_matrix_market::matrix_market_header.
         // This is how you would manipulate the comment field: header.comment = std::string("comment");
         // You may also set header.field = fast_matrix_market::pattern to write a pattern file (only indices, no values).
-        // Non-pattern field types (integer, real, complex) are deduced from the template type and cannot be overriden.
+        // Non-pattern field types (integer, real, complex) are deduced from the template type and cannot be overridden.
 
         fast_matrix_market::write_matrix_market_triplet(
                 oss,

--- a/include/fast_matrix_market/app/CXSparse.hpp
+++ b/include/fast_matrix_market/app/CXSparse.hpp
@@ -22,7 +22,7 @@ namespace fast_matrix_market {
         // Sanitize symmetry generalization settings
         if (options.generalize_symmetry && options.generalize_symmetry_app) {
             // cs_compress drops zero elements
-            options.generalize_coordinate_diagnonal_values = read_options::ExtraZeroElement;
+            options.generalize_coordinate_diagonal_values = read_options::ExtraZeroElement;
         }
 
         // allocate

--- a/include/fast_matrix_market/app/Eigen.hpp
+++ b/include/fast_matrix_market/app/Eigen.hpp
@@ -36,7 +36,7 @@ namespace fast_matrix_market {
         // Sanitize symmetry generalization settings
         if (options.generalize_symmetry && options.generalize_symmetry_app) {
             // setFromTriplets() drops zero elements
-            options.generalize_coordinate_diagnonal_values = read_options::ExtraZeroElement;
+            options.generalize_coordinate_diagonal_values = read_options::ExtraZeroElement;
         }
 
         // read into tuples

--- a/include/fast_matrix_market/app/GraphBLAS.hpp
+++ b/include/fast_matrix_market/app/GraphBLAS.hpp
@@ -560,7 +560,7 @@ namespace fast_matrix_market {
         // Sanitize symmetry generalization settings
         if (options.generalize_symmetry && options.generalize_symmetry_app) {
             // Matrix construction drops zero elements
-            options.generalize_coordinate_diagnonal_values = read_options::ExtraZeroElement;
+            options.generalize_coordinate_diagonal_values = read_options::ExtraZeroElement;
         }
 
 #if FMM_GXB_BUILD_SCALAR

--- a/include/fast_matrix_market/read_body.hpp
+++ b/include/fast_matrix_market/read_body.hpp
@@ -149,7 +149,7 @@ namespace fast_matrix_market {
             }
         } else {
             if (!test_flag(HANDLER::flags, kAppending)) {
-                switch (options.generalize_coordinate_diagnonal_values) {
+                switch (options.generalize_coordinate_diagonal_values) {
                     case read_options::ExtraZeroElement:
                         handler.handle(row, col, get_zero<typename HANDLER::value_type>());
                         break;

--- a/include/fast_matrix_market/types.hpp
+++ b/include/fast_matrix_market/types.hpp
@@ -92,7 +92,7 @@ namespace fast_matrix_market {
         /**
          * If true, perform symmetry generalization in the application binding as a post-processing step.
          * If supported by the binding this method can avoid extra diagonal elements.
-         * If false or unsupported, diagonals are handled according to `generalize_coordinate_diagnonal_values`.
+         * If false or unsupported, diagonals are handled according to `generalize_coordinate_diagonal_values`.
          */
         bool generalize_symmetry_app = true;
 
@@ -108,7 +108,7 @@ namespace fast_matrix_market {
          *  This value is ignored if the parse handler has the kAppending flag set. In that case only a single
          *  diagonal element is emitted.
          */
-        enum {ExtraZeroElement, DuplicateElement} generalize_coordinate_diagnonal_values = ExtraZeroElement;
+        enum {ExtraZeroElement, DuplicateElement} generalize_coordinate_diagonal_values = ExtraZeroElement;
 
         /**
          * Whether parallel implementation is allowed.

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -588,12 +588,12 @@ TEST_P(SymmetrySuite, SmallTripletCoordinate) {
     fast_matrix_market::read_options ro_gen_zero{};
     ro_gen_zero.generalize_symmetry = true;
     ro_gen_zero.generalize_symmetry_app = false;
-    ro_gen_zero.generalize_coordinate_diagnonal_values = fast_matrix_market::read_options::ExtraZeroElement;
+    ro_gen_zero.generalize_coordinate_diagonal_values = fast_matrix_market::read_options::ExtraZeroElement;
 
     fast_matrix_market::read_options ro_gen_dup{};
     ro_gen_dup.generalize_symmetry = true;
     ro_gen_dup.generalize_symmetry_app = false;
-    ro_gen_dup.generalize_coordinate_diagnonal_values = fast_matrix_market::read_options::DuplicateElement;
+    ro_gen_dup.generalize_coordinate_diagonal_values = fast_matrix_market::read_options::DuplicateElement;
 
     fast_matrix_market::read_options ro_gen_app{};
     ro_gen_app.generalize_symmetry = true;


### PR DESCRIPTION
Does the `diagnonal` → `diagonal` change break compatibility?